### PR TITLE
Support Minecraft 1.21.3 and add Simplified Chinese lang file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.6-SNAPSHOT'
+    id 'fabric-loom' version '1.9-SNAPSHOT'
     id 'maven-publish'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,15 +3,15 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
     # check these on https://fabricmc.net/versions.html
-    minecraft_version=1.21
-    yarn_mappings=1.21+build.1
-    loader_version=0.15.11
-    fabric_version=0.100.1+1.21
-    modmenu_version=11.0.0-beta.1
+    minecraft_version=1.21.3
+    yarn_mappings=1.21.3+build.2
+    loader_version=0.16.9
+    fabric_version=0.112.0+1.21.3
+    modmenu_version=12.0.0
     cloth_config_version=14.0.126
 
 # Mod Properties
-    mod_version = 1.6.1
+    mod_version = 1.6.2-alpha
     maven_group = net.naari3.offershud
     archives_base_name = offers-hud
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
+++ b/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
@@ -10,6 +10,7 @@ import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.DrawContext;
 import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.client.render.RenderLayer;
 import net.minecraft.client.render.RenderTickCounter;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -45,7 +46,7 @@ public class OffersHUDRenderer implements HudRenderCallback {
         modelMatrices.translate(config.offsetX, config.offsetY, 1.0);
         modelMatrices.push();
         modelMatrices.scale(config.scale, config.scale, 1.0f);
-        RenderSystem.applyModelViewMatrix();
+        // RenderSystem.applyModelViewMatrix();
 
         MerchantInfo.getInfo().getLastId().ifPresent(lastId -> {
             var offers = MerchantInfo.getInfo().getOffers();
@@ -60,13 +61,13 @@ public class OffersHUDRenderer implements HudRenderCallback {
                 var sell = offer.getSellItem().copy();
 
                 context.drawItem(firstBuy, baseX, baseY);
-                context.drawItemInSlot(textRenderer, firstBuy, baseX, baseY);
+                context.drawStackOverlay(textRenderer, firstBuy, baseX, baseY);
 
                 context.drawItem(secondBuy, baseX + 20, baseY);
-                context.drawItemInSlot(textRenderer, secondBuy, baseX + 20, baseY);
+                context.drawStackOverlay(textRenderer, secondBuy, baseX + 20, baseY);
 
                 context.drawItem(sell, baseX + 53, baseY);
-                context.drawItemInSlot(textRenderer, sell, baseX + 53, baseY);
+                context.drawStackOverlay(textRenderer, sell, baseX + 53, baseY);
 
                 this.renderArrow(context, offer, baseX + -20, baseY);
 
@@ -93,11 +94,18 @@ public class OffersHUDRenderer implements HudRenderCallback {
     // from MerchantScreen
     private void renderArrow(DrawContext context, TradeOffer tradeOffer, int x, int y) {
         if (tradeOffer.isDisabled()) {
-            context.drawTexture(TEXTURE, x + 5 + 35 + 20, y + 3, 0, 25.0F, 171.0F, 10, 9, 512,
-                    256);
+            context.drawTexture(
+                    RenderLayer::getGuiTextured, TEXTURE,
+                    x + 5 + 35 + 20, y + 3,
+                    25.0F, 171.0F,
+                    10, 9,
+                    512, 256);
         } else {
-            context.drawTexture(TEXTURE, x + 5 + 35 + 20, y + 3, 0, 15.0F, 171.0F, 10, 9, 512,
-                    256);
+            context.drawTexture(
+                    RenderLayer::getGuiTextured, TEXTURE,
+                    x + 5 + 35 + 20, y + 3,
+                    15.0F, 171.0F, 10, 9,
+                    512, 256);
         }
     }
 }

--- a/src/main/resources/assets/offershud/lang/zh_cn.json
+++ b/src/main/resources/assets/offershud/lang/zh_cn.json
@@ -1,0 +1,9 @@
+{
+  "text.autoconfig.offershud.title": "Offers HUD",
+  "text.autoconfig.offershud.option.enabled": "启用",
+  "text.autoconfig.offershud.option.ignoreNoProfession": "忽略无业村民",
+  "text.autoconfig.offershud.option.suppressVillagerHeadRolling": "Suppress villager head rolling",
+  "text.autoconfig.offershud.option.offsetX": "HUD X 方向偏移",
+  "text.autoconfig.offershud.option.offsetY": "HUD Y 方向偏移",
+  "text.autoconfig.offershud.option.scale": "HUD 缩放"
+}


### PR DESCRIPTION
Support Minecraft 1.21.3 and add Simplified Chinese lang file.

More infomation:
Maybe bacause the method RenderSystem.applyModelViewMatrix() removed causes the hud below the minihud or other huds, and I don't know how to to let it above.