### PR TITLE
Relax requirement for about Merchant instances

### DIFF
--- a/src/main/java/net/naari3/offershud/OffersHUD.java
+++ b/src/main/java/net/naari3/offershud/OffersHUD.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Objects;
 
 import net.minecraft.item.ItemStack;
+import net.minecraft.village.Merchant;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -15,7 +16,6 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.passive.MerchantEntity;
 import net.minecraft.entity.passive.VillagerEntity;
 import net.minecraft.item.Items;
 import net.minecraft.network.packet.c2s.play.PlayerInteractEntityC2SPacket;
@@ -86,7 +86,7 @@ public class OffersHUD implements ClientModInitializer {
 
         var entityHit = (EntityHitResult) crosshairTarget;
         var entity = entityHit.getEntity();
-        if (!(entity instanceof MerchantEntity merchant)) {
+        if (!(entity instanceof Merchant)) {
             return null;
         }
 
@@ -107,7 +107,7 @@ public class OffersHUD implements ClientModInitializer {
             }
         }
 
-        return merchant;
+        return entity;
     }
 
     public static boolean getOpenWindow() {

--- a/src/main/java/net/naari3/offershud/mixin/ReceiveTradeOfferPacket.java
+++ b/src/main/java/net/naari3/offershud/mixin/ReceiveTradeOfferPacket.java
@@ -1,5 +1,7 @@
 package net.naari3.offershud.mixin;
 
+import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.screen.MerchantScreenHandler;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -18,7 +20,8 @@ import net.minecraft.screen.ScreenHandlerType;
 abstract class ReceiveTradeOfferPacket {
     @Inject(at = @At("HEAD"), method = "onSetTradeOffers", cancellable = true)
     public void onSetTradeOffers(SetTradeOffersS2CPacket packet, CallbackInfo ci) {
-        MerchantInfo.getInfo().setOffers(packet.getOffers());
+        var offers = packet.getOffers();
+        MerchantInfo.getInfo().setOffers(offers);
         if (!OffersHUD.getOpenWindow()) {
             ci.cancel();
         }
@@ -28,7 +31,9 @@ abstract class ReceiveTradeOfferPacket {
     public void onOpenScreen(OpenScreenS2CPacket packet, CallbackInfo ci) {
         var type = packet.getScreenHandlerType();
 
-        if (!OffersHUD.getOpenWindow() && type == ScreenHandlerType.MERCHANT) {
+        var instance = type.create(99999, new PlayerInventory(null));
+
+        if (!OffersHUD.getOpenWindow() && instance instanceof MerchantScreenHandler) {
             ci.cancel();
             ClientPlayNetworking.getSender()
                     .sendPacket(new CloseHandledScreenC2SPacket(packet.getSyncId()));

--- a/src/main/java/net/naari3/offershud/mixin/ValidTrade.java
+++ b/src/main/java/net/naari3/offershud/mixin/ValidTrade.java
@@ -1,5 +1,6 @@
 package net.naari3.offershud.mixin;
 
+import net.minecraft.village.Merchant;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.At;
@@ -9,7 +10,6 @@ import net.naari3.offershud.MerchantInfo;
 import net.naari3.offershud.OffersHUD;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
 import net.minecraft.entity.Entity;
-import net.minecraft.entity.passive.MerchantEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
@@ -20,7 +20,7 @@ abstract class ValidTrade {
     // ClientPlayerInteractionManager
     @Inject(at = @At("HEAD"), method = "interactEntity")
     public void interactEntity(PlayerEntity player, Entity entity, Hand hand, CallbackInfoReturnable<ActionResult> ci) {
-        if (!(entity instanceof MerchantEntity)) {
+        if (!(entity instanceof Merchant)) {
             return;
         }
 
@@ -33,10 +33,9 @@ abstract class ValidTrade {
         // but, From 1.21, merchant.getOffers() is patched that makes it always throw `IllegalStateException` on Client side.
         // I guess that originally it was a method that you didn't want to call on the client side.
         // If this is correct, then this code is meaningless.
-        var merchant = (MerchantEntity) entity;
         var info = MerchantInfo.getInfo();
         info.getLastId().ifPresent(id -> {
-            if (merchant.getId() == id && !info.getOffers().isEmpty()) {
+            if (entity.getId() == id && !info.getOffers().isEmpty()) {
                 OffersHUD.setOpenWindow(true);
             }
         });


### PR DESCRIPTION
closes #51 

This mod performs two separate checks to determine whether an entity is tradeable:

1. It verifies that the focused entity extends `MerchantEntity`.
2. It checks that the `onOpenScreen` packet sent to the client is a `MerchantScreenHandler`.

However, in non-vanilla environments, there can be tradeable mobs that do not meet these conditions.  
For example, in GoblinTraders, the entity does not extend `MerchantEntity` but only implements `Merchant` (which `MerchantEntity` itself implements), and the sent packet is indeed a `MerchantScreenHandler`.  

Because these checks fail in such scenarios and lead to unexpected behavior, the following changes have been made:

1. The entity check now only ensures that it implements `Merchant`.
2. The packet check now verifies that it is a subclass of `MerchantScreenHandler`.
