### PR TITLE
Support 1.21.8

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,7 +14,7 @@ plugins {
 
 stonecutter {
     create(rootProject) {
-        versions "1.21.7", "1.21.5", "1.21.4", "1.21.1", "1.20.6", "1.20.4"
-        vcsVersion = "1.21.7"
+        versions "1.21.8", "1.21.5", "1.21.4", "1.21.1", "1.20.6", "1.20.4"
+        vcsVersion = "1.21.8"
     }
 }

--- a/stonecutter.gradle
+++ b/stonecutter.gradle
@@ -1,7 +1,7 @@
 plugins {
     id "dev.kikugie.stonecutter"
 }
-stonecutter.active "1.21.7" /* [SC] DO NOT EDIT */
+stonecutter.active "1.21.8" /* [SC] DO NOT EDIT */
 
 stonecutter.registerChiseled tasks.register("chiseledBuild", stonecutter.chiseled) { 
     setGroup "project"

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -1,7 +1,7 @@
-minecraft_version=1.21.7
-minecraft_deps=>=1.21.6 <=1.21.7
-yarn_mappings=1.21.7+build.6
-fabric_version=0.128.2+1.21.7
+minecraft_version=1.21.8
+minecraft_deps=>=1.21.6 <=1.21.8
+yarn_mappings=1.21.8+build.1
+fabric_version=0.130.0+1.21.8
 modmenu_version=15.0.0-beta.3
 cloth_config_version=19.0.147
 
@@ -10,4 +10,4 @@ cloth_config_version=19.0.147
 # The Curseforge versions "names" or ids for the main branch (comma separated: 1.16.4,1.16.5)
 # This is needed because CF uses too vague names for prereleases and release candidates
 # Can also be the version ID directly coming from https://minecraft.curseforge.com/api/game/versions?token=[API_TOKEN]
-release-curse-versions = Minecraft 1.21:1.21.7
+release-curse-versions = Minecraft 1.21:1.21.8


### PR DESCRIPTION
Support 1.21.8 by renaming and updating the existing `versions/1.21.7` to target `>=1.21.6 <=1.21.8` instead.

I've never touched minecraft mod development before, so apologies if this is the incorrect approach.

To test, I used `gradle <version>:runClient` for each configured version and performed a quick visual test:
- Version 1.20.4 crashed after pressing "continue" on narrator plash screen and immediately on subsequent starts (both on `main` and this branch).
- Versions 1.20.6 - 1.21.5 all start and run fine, but the offers HUD doesn't render anything (both on `main` and this branch).
- Version 1.21.8 (on this branch) works and the mod functions identically to how it works in 1.21.7 (on `main`).