### PR TITLE
Migrate from Yarn to Parchment+Mojmap mappings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,16 @@ repositories {
     mavenCentral()
     maven { url "https://maven.shedaniel.me/" }
     maven { url "https://maven.terraformersmc.com/releases/" }
+    maven { url "https://maven.parchmentmc.org" }
 }
 
 dependencies {
     // To change the versions see the gradle.properties file
     minecraft "com.mojang:minecraft:${stonecutter.current.project}"
-    mappings "net.fabricmc:yarn:${property('yarn_mappings')}:v2"
+    mappings loom.layered() {
+        officialMojangMappings()
+        parchment("org.parchmentmc.data:parchment-${property('parchment_version')}@zip")
+    }
     modImplementation "net.fabricmc:fabric-loader:${property('loader_version')}"
 
     // Fabric API. This is technically optional, but you probably want it anyway.

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ org.gradle.jvmargs=-Xmx1G
 # check these on https://fabricmc.net/versions.html
 minecraft_version=[VERSIONED]
 minecraft_deps=[VERSIONED]
-yarn_mappings=[VERSIONED]
+parchment_version=[VERSIONED]
 loader_version=0.18.4
 fabric_version=[VERSIONED]
 modmenu_version=[VERSIONED]

--- a/src/main/java/net/naari3/offershud/MerchantInfo.java
+++ b/src/main/java/net/naari3/offershud/MerchantInfo.java
@@ -7,7 +7,7 @@ import java.util.Optional;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import net.minecraft.village.TradeOffer;
+import net.minecraft.world.item.trading.MerchantOffer;
 
 public class MerchantInfo {
     private static MerchantInfo info = new MerchantInfo();
@@ -16,17 +16,17 @@ public class MerchantInfo {
     private Integer lastId;
 
     @NotNull
-    private List<TradeOffer> offers = new ArrayList<>();
+    private List<MerchantOffer> offers = new ArrayList<>();
 
     public static MerchantInfo getInfo() {
         return info;
     }
 
-    public List<TradeOffer> getOffers() {
+    public List<MerchantOffer> getOffers() {
         return this.offers;
     }
 
-    public void setOffers(List<TradeOffer> offerlist) {
+    public void setOffers(List<MerchantOffer> offerlist) {
         this.offers = offerlist;
     }
 

--- a/src/main/java/net/naari3/offershud/mixin/CloseScreen.java
+++ b/src/main/java/net/naari3/offershud/mixin/CloseScreen.java
@@ -6,12 +6,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.At;
 
 import net.naari3.offershud.OffersHUD;
-import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.player.LocalPlayer;
 
-@Mixin(ClientPlayerEntity.class)
+@Mixin(LocalPlayer.class)
 abstract class CloseScreen {
-    @Inject(at = @At("HEAD"), method = "closeHandledScreen")
-    public void closeHandledScreen(CallbackInfo ci) {
+    @Inject(at = @At("HEAD"), method = "closeContainer")
+    public void closeContainer(CallbackInfo ci) {
         OffersHUD.setOpenWindow(false);
     }
 }

--- a/src/main/java/net/naari3/offershud/mixin/NoRolling.java
+++ b/src/main/java/net/naari3/offershud/mixin/NoRolling.java
@@ -8,14 +8,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.entity.passive.MerchantEntity;
+/*? if >= 1.21.11 {*/
+import net.minecraft.world.entity.npc.villager.AbstractVillager;
+/*?} else {*/
+/*import net.minecraft.world.entity.npc.AbstractVillager;
+*//*?}*/
 import net.naari3.offershud.config.ModConfig;
 
-@Mixin(MerchantEntity.class)
+@Mixin(AbstractVillager.class)
 @Environment(EnvType.CLIENT)
 public abstract class NoRolling {
-    @Inject(at = @At("HEAD"), method = "getHeadRollingTimeLeft", cancellable = true)
-    public void getHeadRollingTimeLeft(CallbackInfoReturnable<Integer> ci) {
+    @Inject(at = @At("HEAD"), method = "getUnhappyCounter", cancellable = true)
+    public void getUnhappyCounter(CallbackInfoReturnable<Integer> ci) {
         var config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
         if (config.suppressVillagerHeadRolling) {
             ci.setReturnValue(0);

--- a/src/main/java/net/naari3/offershud/mixin/NoRollingSound.java
+++ b/src/main/java/net/naari3/offershud/mixin/NoRollingSound.java
@@ -8,9 +8,9 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import me.shedaniel.autoconfig.AutoConfig;
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
-import net.minecraft.entity.Entity;
-import net.minecraft.sound.SoundEvent;
-import net.minecraft.sound.SoundEvents;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.sounds.SoundEvent;
+import net.minecraft.sounds.SoundEvents;
 import net.naari3.offershud.config.ModConfig;
 
 @Mixin(Entity.class)
@@ -19,7 +19,7 @@ public abstract class NoRollingSound {
     @Inject(at = @At("HEAD"), method = "playSound", cancellable = true)
     public void playSound(SoundEvent sound, float volume, float pitch, CallbackInfo ci) {
         var config = AutoConfig.getConfigHolder(ModConfig.class).getConfig();
-        if (config.suppressVillagerHeadRolling && SoundEvents.ENTITY_VILLAGER_NO == sound) {
+        if (config.suppressVillagerHeadRolling && SoundEvents.VILLAGER_NO == sound) {
             ci.cancel();
         }
     }

--- a/src/main/java/net/naari3/offershud/mixin/ValidTrade.java
+++ b/src/main/java/net/naari3/offershud/mixin/ValidTrade.java
@@ -1,6 +1,6 @@
 package net.naari3.offershud.mixin;
 
-import net.minecraft.village.Merchant;
+import net.minecraft.world.item.trading.Merchant;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.At;
@@ -8,18 +8,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import net.naari3.offershud.MerchantInfo;
 import net.naari3.offershud.OffersHUD;
-import net.minecraft.client.network.ClientPlayerInteractionManager;
-import net.minecraft.entity.Entity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.util.ActionResult;
-import net.minecraft.util.Hand;
+import net.minecraft.client.multiplayer.MultiPlayerGameMode;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.InteractionResult;
+import net.minecraft.world.InteractionHand;
 
-@Mixin(ClientPlayerInteractionManager.class)
+@Mixin(MultiPlayerGameMode.class)
 abstract class ValidTrade {
 
-    // ClientPlayerInteractionManager
-    @Inject(at = @At("HEAD"), method = "interactEntity")
-    public void interactEntity(PlayerEntity player, Entity entity, Hand hand, CallbackInfoReturnable<ActionResult> ci) {
+    // MultiPlayerGameMode
+    @Inject(at = @At("HEAD"), method = "interact")
+    public void interact(Player player, Entity entity, InteractionHand hand, CallbackInfoReturnable<InteractionResult> ci) {
         if (!(entity instanceof Merchant)) {
             return;
         }

--- a/versions/1.20.4/gradle.properties
+++ b/versions/1.20.4/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.20.4
 minecraft_deps=>=1.20 <=1.20.4
-yarn_mappings=1.20.4+build.3
+parchment_version=1.20.4:2024.04.14
 fabric_version=0.97.2+1.20.4
 modmenu_version=9.0.0
 cloth_config_version=13.0.138

--- a/versions/1.20.6/gradle.properties
+++ b/versions/1.20.6/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.20.6
 minecraft_deps=>=1.20.5 <=1.20.6
-yarn_mappings=1.20.6+build.3
+parchment_version=1.20.6:2024.06.16
 fabric_version=0.100.8+1.20.6
 modmenu_version=10.0.0
 cloth_config_version=14.0.139

--- a/versions/1.21.1/gradle.properties
+++ b/versions/1.21.1/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.1
 minecraft_deps=>=1.21 <=1.21.1
-yarn_mappings=1.21.1+build.3
+parchment_version=1.21:2024.07.28
 fabric_version=0.110.0+1.21.1
 modmenu_version=11.0.3
 cloth_config_version=14.0.126

--- a/versions/1.21.10/gradle.properties
+++ b/versions/1.21.10/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.10
 minecraft_deps=>=1.21.10 <=1.21.10
-yarn_mappings=1.21.10+build.2
+parchment_version=1.21.10:2025.10.12
 fabric_version=0.135.0+1.21.10
 modmenu_version=16.0.0-rc.1
 cloth_config_version=20.0.148

--- a/versions/1.21.11/gradle.properties
+++ b/versions/1.21.11/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.11
 minecraft_deps=>=1.21.11 <=1.21.11
-yarn_mappings=1.21.11+build.3
+parchment_version=1.21.11:2025.12.20
 fabric_version=0.140.2+1.21.11
 modmenu_version=17.0.0-beta.1
 cloth_config_version=21.11.153

--- a/versions/1.21.4/gradle.properties
+++ b/versions/1.21.4/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.4
 minecraft_deps=>=1.21.2 <=1.21.4
-yarn_mappings=1.21.4+build.2
+parchment_version=1.21.4:2024.12.07
 fabric_version=0.113.0+1.21.4
 modmenu_version=12.0.0
 cloth_config_version=14.0.126

--- a/versions/1.21.5/gradle.properties
+++ b/versions/1.21.5/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.5
 minecraft_deps=1.21.5
-yarn_mappings=1.21.5+build.1
+parchment_version=1.21.5:2025.06.15
 fabric_version=0.125.0+1.21.5
 modmenu_version=14.0.0-rc.2
 cloth_config_version=18.0.145

--- a/versions/1.21.8/gradle.properties
+++ b/versions/1.21.8/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.8
 minecraft_deps=>=1.21.6 <=1.21.8
-yarn_mappings=1.21.8+build.1
+parchment_version=1.21.8:2025.09.14
 fabric_version=0.130.0+1.21.8
 modmenu_version=15.0.0-beta.3
 cloth_config_version=19.0.147

--- a/versions/1.21.9/gradle.properties
+++ b/versions/1.21.9/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.21.9
 minecraft_deps=>=1.21.9 <=1.21.9
-yarn_mappings=1.21.9+build.1
+parchment_version=1.21.9:2025.10.05
 fabric_version=0.134.0+1.21.9
 modmenu_version=16.0.0-rc.1
 cloth_config_version=20.0.148


### PR DESCRIPTION
## Summary
- Migrate from Yarn mappings to Parchment+Mojmap mappings
- All versions (1.20.4 - 1.21.11) build successfully

## Changes
- Convert class/method/field names to Parchment+Mojmap
- Add version-specific import branches (DeltaTracker, Identifier/ResourceLocation, AbstractVillager)
- Fix enchantment handling with proper 3-way version branching (1.21+, 1.20.6, 1.20.4)
- Unify getCostA/getCostB across all versions
- Rename BACKGROUND_TEXTURE to INVENTORY_LOCATION

## Test plan
- [x] 1.20.4 build success
- [x] 1.20.6 build success
- [x] 1.21.1 build success
- [x] 1.21.4 build success
- [x] 1.21.5 build success
- [x] 1.21.8 build success
- [x] 1.21.9 build success
- [x] 1.21.10 build success
- [x] 1.21.11 build success

🤖 Generated with [Claude Code](https://claude.com/claude-code)