### PR TITLE
Support 26.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,11 +46,11 @@ jobs:
           echo "curse-versions=${{ needs.get-properties.outputs.curse-versions }}" >> $GITHUB_OUTPUT
       - name: Checkout the sources
         uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v4
         with:
           distribution: "temurin"
-          java-version: 21
+          java-version: 25
       - name: Cache Gradle packages
         uses: actions/cache@v4
         with:
@@ -110,11 +110,15 @@ jobs:
           echo "loader=$loader" >> $GITHUB_OUTPUT
           echo "Detected: MC $version, Loader: $loader"
 
-          # Read minecraft_deps from version-specific gradle.properties
+          # Read minecraft_deps and java_version from version-specific gradle.properties
           props_file="versions/${full_version}/gradle.properties"
           minecraft_deps=$(grep "^minecraft_deps=" "$props_file" | cut -d'=' -f2-)
           echo "game-versions=$minecraft_deps" >> $GITHUB_OUTPUT
           echo "Game versions: $minecraft_deps"
+
+          java_version=$(grep "^java_version=" "$props_file" | cut -d'=' -f2- || echo "21")
+          echo "java-version=${java_version:-21}" >> $GITHUB_OUTPUT
+          echo "Java version: ${java_version:-21}"
       - name: Publish to Curseforge and Modrinth
         uses: Kira-NT/mc-publish@v3
         with:
@@ -129,5 +133,5 @@ jobs:
           loaders: |
             ${{ steps.getmcversion.outputs.loader }}
           java: |
-            21
+            ${{ steps.getmcversion.outputs.java-version }}
           files: ${{ matrix.file }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,9 @@ import org.gradle.jvm.tasks.Jar
 
 plugins {
     id("dev.kikugie.stonecutter")
-    id("dev.architectury.loom") version "1.13-SNAPSHOT" apply false
-    id("architectury-plugin") version "3.4-SNAPSHOT" apply false
+    id("dev.architectury.loom") version "1.14.473" apply false
+    id("dev.architectury.loom-no-remap") version "1.14.473" apply false
+    id("architectury-plugin") version "3.5.163" apply false
     id("maven-publish")
 }
 
@@ -18,9 +19,14 @@ stonecutter {
 
 // Extract MC version from project name
 val mcVersion = current.replace("-fabric", "").replace("-neoforge", "")
+val isUnobfuscated = stonecutter.current.version >= "26.1"
 
-// Apply Architectury plugins
-apply(plugin = "dev.architectury.loom")
+// Apply Architectury plugins - use no-remap for unobfuscated versions (26.1+)
+if (isUnobfuscated) {
+    apply(plugin = "dev.architectury.loom-no-remap")
+} else {
+    apply(plugin = "dev.architectury.loom")
+}
 apply(plugin = "architectury-plugin")
 
 extensions.configure<dev.architectury.plugin.ArchitectPluginExtension> {
@@ -31,13 +37,38 @@ extensions.configure<dev.architectury.plugin.ArchitectPluginExtension> {
     }
 }
 
+// Workaround: prepareArchitecturyTransformer scans all Loom projects including
+// unobfuscated ones (26.1+) and fails when trying to get their mappings.
+// For unobfuscated versions, replace the task with one that writes a minimal
+// properties file (no remapping needed). For obfuscated versions, also disable
+// the original task since it scans cross-project and hits unobfuscated ones.
+tasks.matching { it.name == "prepareArchitecturyTransformer" }.configureEach {
+    enabled = false
+}
+
+tasks.register("createArchitecturyProperties") {
+    val propsDir = project.projectDir.resolve(".gradle/architectury")
+    val propsFile = propsDir.resolve(".properties")
+    val transformsFile = propsDir.resolve(".transforms")
+    outputs.files(propsFile, transformsFile)
+    doLast {
+        propsDir.mkdirs()
+        propsFile.writeText("")
+        transformsFile.writeText("")
+    }
+}
+
+tasks.matching { it.name == "runClient" || it.name == "runServer" }.configureEach {
+    dependsOn("createArchitecturyProperties")
+}
+
 extensions.configure<BasePluginExtension> {
     archivesName.set(property("archives_base_name") as String)
 }
 version = "${property("mod_version")}+${stonecutter.current.project}"
 group = property("maven_group") as String
 
-val javaInt = 21
+val javaInt = (findProperty("java_version") as String?)?.toIntOrNull() ?: 21
 
 repositories {
     mavenCentral()
@@ -58,23 +89,31 @@ loom.apply {
 
 dependencies {
     "minecraft"("com.mojang:minecraft:$mcVersion")
-    "mappings"(loom.layered {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${property("parchment_version")}@zip")
-    })
+    if (!isUnobfuscated) {
+        "mappings"(loom.layered {
+            officialMojangMappings()
+            val parchmentVersion = findProperty("parchment_version") as String?
+            if (!parchmentVersion.isNullOrBlank()) {
+                parchment("org.parchmentmc.data:parchment-${parchmentVersion}@zip")
+            }
+        })
+    }
+
+    val modImpl = if (isUnobfuscated) "implementation" else "modImplementation"
+    val modApi = if (isUnobfuscated) "api" else "modApi"
 
     if (isFabric) {
-        "modImplementation"("net.fabricmc:fabric-loader:${property("loader_version")}")
-        "modImplementation"("net.fabricmc.fabric-api:fabric-api:${property("fabric_version")}")
-        "modImplementation"("com.terraformersmc:modmenu:${property("modmenu_version")}") {
+        modImpl("net.fabricmc:fabric-loader:${property("loader_version")}")
+        modImpl("net.fabricmc.fabric-api:fabric-api:${property("fabric_version")}")
+        modImpl("com.terraformersmc:modmenu:${property("modmenu_version")}") {
             exclude(module = "fabric-api")
         }
-        "modApi"("me.shedaniel.cloth:cloth-config-fabric:${property("cloth_config_version")}") {
+        modApi("me.shedaniel.cloth:cloth-config-fabric:${property("cloth_config_version")}") {
             exclude(module = "fabric-api")
         }
     } else {
         "neoForge"("net.neoforged:neoforge:${property("neoforge_version")}")
-        "modImplementation"("me.shedaniel.cloth:cloth-config-neoforge:${property("cloth_config_version")}")
+        modImpl("me.shedaniel.cloth:cloth-config-neoforge:${property("cloth_config_version")}")
     }
 }
 
@@ -124,7 +163,7 @@ tasks.withType<JavaCompile>().configureEach {
 
 extensions.configure<JavaPluginExtension> {
     withSourcesJar()
-    val javaObj = JavaVersion.VERSION_21
+    val javaObj = JavaVersion.toVersion(javaInt)
     sourceCompatibility = javaObj
     targetCompatibility = javaObj
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,8 @@ stonecutter {
     centralScript = "build.gradle.kts"
 
     create(rootProject) {
+        version("26.1-fabric", "26.1")
+        version("26.1-neoforge", "26.1")
         version("1.21.11-fabric", "1.21.11")
         version("1.21.11-neoforge", "1.21.11")
         version("1.21.10-fabric", "1.21.10")
@@ -42,6 +44,6 @@ stonecutter {
         version("1.21.1-neoforge", "1.21.1")
         version("1.20.6-fabric", "1.20.6")
         version("1.20.6-neoforge", "1.20.6")
-        vcsVersion = "1.21.11-fabric"
+        vcsVersion = "26.1-fabric"
     }
 }

--- a/src/main/java/net/naari3/offershud/OffersHUD.java
+++ b/src/main/java/net/naari3/offershud/OffersHUD.java
@@ -78,10 +78,18 @@ public class OffersHUD implements ClientModInitializer {
                 MerchantInfo.getInfo().setLastId(entity.getId());
 
                 if (mc.player != null) {
+                    /*? if >= 26.1 {*/
                     platform.sendPacketToServer(
+                            new ServerboundInteractPacket(entity.getId(),
+                                    InteractionHand.MAIN_HAND,
+                                    net.minecraft.world.phys.Vec3.ZERO,
+                                    mc.player.isShiftKeyDown()));
+                    /*?} else {*/
+                    /*platform.sendPacketToServer(
                             ServerboundInteractPacket.createInteractionPacket(entity,
                                     mc.player.isShiftKeyDown(),
                                     InteractionHand.MAIN_HAND));
+                    *//*?}*/
                 }
             } else {
                 MerchantInfo.getInfo().setLastId(null);

--- a/src/main/java/net/naari3/offershud/config/ModMenuIntegration.java
+++ b/src/main/java/net/naari3/offershud/config/ModMenuIntegration.java
@@ -4,7 +4,11 @@ package net.naari3.offershud.config;
 import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import com.terraformersmc.modmenu.api.ModMenuApi;
 
-import me.shedaniel.autoconfig.AutoConfig;
+/*? if >= 26.1 {*/
+import me.shedaniel.autoconfig.AutoConfigClient;
+/*?} else {*/
+/*import me.shedaniel.autoconfig.AutoConfig;
+*//*?}*/
 import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 
@@ -12,7 +16,11 @@ import net.fabricmc.api.Environment;
 public class ModMenuIntegration implements ModMenuApi {
     @Override
     public ConfigScreenFactory<?> getModConfigScreenFactory() {
-        return parent -> AutoConfig.getConfigScreen(ModConfig.class, parent).get();
+        /*? if >= 26.1 {*/
+        return parent -> AutoConfigClient.getConfigScreen(ModConfig.class, parent).get();
+        /*?} else {*/
+        /*return parent -> AutoConfig.getConfigScreen(ModConfig.class, parent).get();
+        *//*?}*/
     }
 }
 //?}

--- a/src/main/java/net/naari3/offershud/mixin/ValidTrade.java
+++ b/src/main/java/net/naari3/offershud/mixin/ValidTrade.java
@@ -13,13 +13,20 @@ import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionHand;
+/*? if >= 26.1 {*/
+import net.minecraft.world.phys.EntityHitResult;
+/*?}*/
 
 @Mixin(MultiPlayerGameMode.class)
 abstract class ValidTrade {
 
     // MultiPlayerGameMode
     @Inject(at = @At("HEAD"), method = "interact")
-    public void interact(Player player, Entity entity, InteractionHand hand, CallbackInfoReturnable<InteractionResult> ci) {
+    /*? if >= 26.1 {*/
+    public void interact(Player player, Entity entity, EntityHitResult hitResult, InteractionHand hand, CallbackInfoReturnable<InteractionResult> ci) {
+    /*?} else {*/
+    /*public void interact(Player player, Entity entity, InteractionHand hand, CallbackInfoReturnable<InteractionResult> ci) {
+    *//*?}*/
         if (!(entity instanceof Merchant)) {
             return;
         }

--- a/src/main/java/net/naari3/offershud/platform/FabricPlatform.java
+++ b/src/main/java/net/naari3/offershud/platform/FabricPlatform.java
@@ -3,7 +3,14 @@ package net.naari3.offershud.platform;
 
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+/*? if >= 26.1 {*/
+import net.fabricmc.fabric.api.client.rendering.v1.hud.HudElementRegistry;
+import net.fabricmc.fabric.api.client.rendering.v1.hud.VanillaHudElements;
+import net.minecraft.resources.Identifier;
+import net.naari3.offershud.OffersHUD;
+/*?} else {*/
+/*import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+*//*?}*/
 import net.minecraft.network.protocol.Packet;
 
 public class FabricPlatform implements Platform {
@@ -18,15 +25,25 @@ public class FabricPlatform implements Platform {
 
     @Override
     public void registerClientTickHandler(Runnable handler) {
-        ClientTickEvents.END_WORLD_TICK.register(world -> handler.run());
+        /*? if >= 26.1 {*/
+        ClientTickEvents.END_LEVEL_TICK.register(world -> handler.run());
+        /*?} else {*/
+        /*ClientTickEvents.END_WORLD_TICK.register(world -> handler.run());
+        *//*?}*/
     }
 
     @Override
     public void registerHudRenderer(HudRenderer renderer) {
-        /*? if >= 1.21 {*/
-        HudRenderCallback.EVENT.register((graphics, deltaTracker) ->
+        /*? if >= 26.1 {*/
+        HudElementRegistry.attachElementAfter(
+            VanillaHudElements.HOTBAR,
+            Identifier.fromNamespaceAndPath(OffersHUD.MODID, "offers"),
+            renderer::extractRenderState
+        );
+        /*?} else if >= 1.21 {*/
+        /*HudRenderCallback.EVENT.register((graphics, deltaTracker) ->
             renderer.render(graphics, deltaTracker));
-        /*?} else {*/
+        *//*?} else {*/
         /*HudRenderCallback.EVENT.register((graphics, tickDelta) ->
             renderer.render(graphics, tickDelta));
         *//*?}*/

--- a/src/main/java/net/naari3/offershud/platform/NeoForgePlatform.java
+++ b/src/main/java/net/naari3/offershud/platform/NeoForgePlatform.java
@@ -35,7 +35,11 @@ public class NeoForgePlatform implements Platform {
     public void registerHudRenderer(HudRenderer renderer) {
         NeoForge.EVENT_BUS.addListener(RenderGuiLayerEvent.Post.class, event -> {
             if (event.getName().equals(VanillaGuiLayers.HOTBAR)) {
-                renderer.render(event.getGuiGraphics(), event.getPartialTick());
+                //? if >= 26.1 {
+                renderer.extractRenderState(event.getGuiGraphics(), event.getPartialTick());
+                //?} else {
+                /^renderer.render(event.getGuiGraphics(), event.getPartialTick());
+                ^///?}
             }
         });
     }

--- a/src/main/java/net/naari3/offershud/platform/Platform.java
+++ b/src/main/java/net/naari3/offershud/platform/Platform.java
@@ -1,6 +1,10 @@
 package net.naari3.offershud.platform;
 
-import net.minecraft.client.gui.GuiGraphics;
+/*? if >= 26.1 {*/
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+/*?} else {*/
+/*import net.minecraft.client.gui.GuiGraphics;
+*//*?}*/
 import net.minecraft.network.protocol.Packet;
 
 public interface Platform {
@@ -10,9 +14,11 @@ public interface Platform {
 
     @FunctionalInterface
     interface HudRenderer {
-        /*? if >= 1.21 {*/
-        void render(GuiGraphics graphics, net.minecraft.client.DeltaTracker deltaTracker);
-        /*?} else {*/
+        /*? if >= 26.1 {*/
+        void extractRenderState(GuiGraphicsExtractor graphics, net.minecraft.client.DeltaTracker deltaTracker);
+        /*?} else if >= 1.21 {*/
+        /*void render(GuiGraphics graphics, net.minecraft.client.DeltaTracker deltaTracker);
+        *//*?} else {*/
         /*void render(GuiGraphics graphics, float tickDelta);
         *//*?}*/
     }

--- a/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
+++ b/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
@@ -6,12 +6,16 @@ import java.util.List;
 import com.mojang.blaze3d.systems.RenderSystem;
 
 import me.shedaniel.autoconfig.AutoConfig;
-//? if fabric {
-import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
-//?}
+//? if fabric && < 26.1 {
+/*import net.fabricmc.fabric.api.client.rendering.v1.HudRenderCallback;
+*///?}
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.Font;
-import net.minecraft.client.gui.GuiGraphics;
+/*? if >= 26.1 {*/
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+/*?} else {*/
+/*import net.minecraft.client.gui.GuiGraphics;
+*//*?}*/
 import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 /*? if >= 1.21.3 && < 1.21.6 {*/
 /*import net.minecraft.client.renderer.RenderType;
@@ -37,9 +41,11 @@ import net.naari3.offershud.platform.Platform;
 import net.minecraft.client.renderer.RenderPipelines;
 /*?}*/
 
-//? if fabric {
-public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRenderer {
-//?} else {
+/*? if >= 26.1 {*/
+public class OffersHUDRenderer implements Platform.HudRenderer {
+/*?} else if fabric {*/
+/*public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRenderer {
+*//*?} else {*/
 /*public class OffersHUDRenderer implements Platform.HudRenderer {
 *//*?}*/
     /*? if >= 1.21.11 {*/
@@ -54,8 +60,11 @@ public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRendere
     *//*?}*/
 
 
-    /*? if >=1.21 {*/
-    //? if fabric {
+    /*? if >= 26.1 {*/
+    @Override
+    public void extractRenderState(GuiGraphicsExtractor context, DeltaTracker tickCounter) {
+    /*?} else if >=1.21 {*/
+    /*//? if fabric {
     @Override
     public void onHudRender(GuiGraphics context, DeltaTracker tickCounter) {
         render(context, tickCounter);
@@ -64,7 +73,7 @@ public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRendere
 
     @Override
     public void render(GuiGraphics context, DeltaTracker tickCounter) {
-    /*?} else {*/
+    *//*?} else {*/
     /*//? if fabric {
     @Override
     public void onHudRender(GuiGraphics context, float tickDelta) {
@@ -93,13 +102,22 @@ public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRendere
         RenderSystem.setShaderTexture(0, AbstractContainerScreen.INVENTORY_LOCATION);
         *//*?}*/
 
+        /*? if >= 26.1 {*/
         var modelMatrices = context.pose();
+        /*?} else {*/
+        /*var modelMatrices = context.pose();
+        *//*?}*/
 
         MerchantInfo.getInfo().getLastId().ifPresent(lastId -> {
             var offers = MerchantInfo.getInfo().getOffers();
 
-            int screenWidth = client.getWindow().getGuiScaledWidth();
+            /*? if >= 26.1 {*/
+            int screenWidth = context.guiWidth();
+            int screenHeight = context.guiHeight();
+            /*?} else {*/
+            /*int screenWidth = client.getWindow().getGuiScaledWidth();
             int screenHeight = client.getWindow().getGuiScaledHeight();
+            *//*?}*/
             float scale = config.scale;
 
             float translateX = config.alignment.isRight() ?
@@ -140,7 +158,17 @@ public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRendere
                 var secondBuy = offer.getCostB().copy();
                 var sell = offer.getResult().copy();
 
-                context.renderItem(firstBuy, baseX, baseY);
+                /*? if >= 26.1 {*/
+                context.item(firstBuy, baseX, baseY);
+                context.itemDecorations(textRenderer, firstBuy, baseX, baseY);
+
+                context.item(secondBuy, baseX + 20, baseY);
+                context.itemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
+
+                context.item(sell, baseX + 53, baseY);
+                context.itemDecorations(textRenderer, sell, baseX + 53, baseY);
+                /*?} else {*/
+                /*context.renderItem(firstBuy, baseX, baseY);
                 context.renderItemDecorations(textRenderer, firstBuy, baseX, baseY);
 
                 context.renderItem(secondBuy, baseX + 20, baseY);
@@ -148,12 +176,17 @@ public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRendere
 
                 context.renderItem(sell, baseX + 53, baseY);
                 context.renderItemDecorations(textRenderer, sell, baseX + 53, baseY);
+                *//*?}*/
 
                 this.renderArrow(context, offer, baseX + -20, baseY);
 
                 var enchantments = getEnchantmentText(offer);
 
-                context.drawString(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
+                /*? if >= 26.1 {*/
+                context.text(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
+                /*?} else {*/
+                /*context.drawString(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
+                *//*?}*/
                 i += 1;
             }
 
@@ -166,7 +199,11 @@ public class OffersHUDRenderer implements HudRenderCallback, Platform.HudRendere
     }
 
     // from MerchantScreen
-    private void renderArrow(GuiGraphics context, MerchantOffer tradeOffer, int x, int y) {
+    /*? if >= 26.1 {*/
+    private void renderArrow(GuiGraphicsExtractor context, MerchantOffer tradeOffer, int x, int y) {
+    /*?} else {*/
+    /*private void renderArrow(GuiGraphics context, MerchantOffer tradeOffer, int x, int y) {
+    *//*?}*/
         if (tradeOffer.isOutOfStock()) {
             //? if >=1.21.6 {
             context.blit(

--- a/stonecutter.gradle.kts
+++ b/stonecutter.gradle.kts
@@ -2,4 +2,4 @@ plugins {
     id("dev.kikugie.stonecutter")
 }
 
-stonecutter active "1.21.11-fabric" /* [SC] DO NOT EDIT */
+stonecutter active "26.1-fabric" /* [SC] DO NOT EDIT */

--- a/versions/26.1-fabric/gradle.properties
+++ b/versions/26.1-fabric/gradle.properties
@@ -1,0 +1,14 @@
+loom.platform=fabric
+minecraft_version=26.1
+minecraft_deps=>=26.1 <=26.1
+java_version=25
+fabric_version=0.145.0+26.1
+modmenu_version=18.0.0-alpha.8
+cloth_config_version=26.1.154
+
+# Release Action properties for Curseforge and Snapshots
+# This is from https://github.com/gnembon/fabric-carpet 's ones.
+# The Curseforge versions "names" or ids for the main branch (comma separated: 1.16.4,1.16.5)
+# This is needed because CF uses too vague names for prereleases and release candidates
+# Can also be the version ID directly coming from https://minecraft.curseforge.com/api/game/versions?token=[API_TOKEN]
+release-curse-versions = Minecraft 26:26.1

--- a/versions/26.1-neoforge/gradle.properties
+++ b/versions/26.1-neoforge/gradle.properties
@@ -1,0 +1,11 @@
+loom.platform=neoforge
+minecraft_version=26.1
+mc_deps_version=[26.1]
+minecraft_deps=>=26.1 <=26.1
+java_version=25
+neoforge_version=26.1.0.8-beta
+neoforge_version_range=[26.1,)
+loader_version_range=[4,)
+cloth_config_version=26.1.154
+
+release-curse-versions = Minecraft 26:26.1


### PR DESCRIPTION
## Summary
- Add Minecraft 26.1 support for both Fabric and NeoForge
- Update build toolchain: Gradle 9.4.0, Architectury Loom 1.14.473 (`loom-no-remap`), Architectury Plugin 3.5.163
- Adapt to 26.1 breaking changes: `HudRenderCallback` → `HudElementRegistry`, `GuiGraphics` → `GuiGraphicsExtractor`, `ServerboundInteractPacket` record, etc.
- Update CI workflows to Java 25

🤖 Generated with [Claude Code](https://claude.com/claude-code)