### PR TITLE
Highlight enchanted book trades at cheapest/priciest base price

### DIFF
--- a/src/main/java/net/naari3/offershud/config/ModConfig.java
+++ b/src/main/java/net/naari3/offershud/config/ModConfig.java
@@ -10,6 +10,7 @@ public class ModConfig implements ConfigData {
     public boolean enabled = true;
     public boolean ignoreNoProfession = true;
     public boolean suppressVillagerHeadRolling = false;
+    public boolean highlightExtremePrices = true;
 
     @ConfigEntry.Gui.EnumHandler(option = ConfigEntry.Gui.EnumHandler.EnumDisplayOption.BUTTON)
     public Alignment alignment = Alignment.TOP_LEFT;

--- a/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
+++ b/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
@@ -23,14 +23,19 @@ import net.minecraft.client.gui.screens.inventory.AbstractContainerScreen;
 /*? if >= 1.21 {*/
 import net.minecraft.client.DeltaTracker;
 /*?}*/
+import net.minecraft.core.Holder;
 import net.minecraft.world.item.enchantment.Enchantment;
 import net.minecraft.world.item.enchantment.EnchantmentHelper;
+/*? if >= 1.21 {*/
+import net.minecraft.tags.EnchantmentTags;
+/*?}*/
 import net.minecraft.util.CommonColors;
 /*? if >= 1.21.11 {*/
 import net.minecraft.resources.Identifier;
 /*?} else {*/
 /*import net.minecraft.resources.ResourceLocation;
 *//*?}*/
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.trading.MerchantOffer;
 import net.naari3.offershud.MerchantInfo;
 import net.naari3.offershud.OffersHUD;
@@ -158,9 +163,13 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
                 var secondBuy = offer.getCostB().copy();
                 var sell = offer.getResult().copy();
 
+                int firstBuyColor = config.highlightExtremePrices
+                        ? computeExtremePriceColor(offer)
+                        : COLOR_NORMAL_COST;
+
                 /*? if >= 26.1 {*/
                 context.item(firstBuy, baseX, baseY);
-                context.itemDecorations(textRenderer, firstBuy, baseX, baseY);
+                renderFirstBuyDecorations(context, textRenderer, firstBuy, baseX, baseY, firstBuyColor);
 
                 context.item(secondBuy, baseX + 20, baseY);
                 context.itemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
@@ -169,7 +178,7 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
                 context.itemDecorations(textRenderer, sell, baseX + 53, baseY);
                 /*?} else {*/
                 /*context.renderItem(firstBuy, baseX, baseY);
-                context.renderItemDecorations(textRenderer, firstBuy, baseX, baseY);
+                renderFirstBuyDecorations(context, textRenderer, firstBuy, baseX, baseY, firstBuyColor);
 
                 context.renderItem(secondBuy, baseX + 20, baseY);
                 context.renderItemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
@@ -197,6 +206,80 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
             *//*?}*/;
         });
     }
+
+    private static final int COLOR_NORMAL_COST = 0xFFFFFFFF;
+    private static final int COLOR_LOWEST_COST = 0xFF55FF55;
+    private static final int COLOR_HIGHEST_COST = 0xFFFF5555;
+
+    // Enchanted-book trades price emeralds at baseCost = (2 + rand[0..4+10k] + 3k), doubled for
+    // #double_trade_price (treasure) enchantments, capped at 64. The range bounds for a fixed level
+    // k are therefore [2+3k, 6+13k]. Spotting baseCostA at either bound flags the best/worst roll.
+    private static int computeExtremePriceColor(MerchantOffer offer) {
+        var enchantments = EnchantmentHelper.getEnchantmentsForCrafting(offer.getResult());
+        if (enchantments.size() != 1) {
+            return COLOR_NORMAL_COST;
+        }
+        var entry = enchantments.entrySet().iterator().next();
+        int level = entry.getIntValue();
+        int min = 2 + 3 * level;
+        int max = 6 + 13 * level;
+        if (isDoubleTradePrice(entry.getKey())) {
+            min *= 2;
+            max *= 2;
+        }
+        min = Math.min(min, 64);
+        max = Math.min(max, 64);
+        int base = offer.getBaseCostA().getCount();
+        if (base <= min) {
+            return COLOR_LOWEST_COST;
+        }
+        if (base >= max) {
+            return COLOR_HIGHEST_COST;
+        }
+        return COLOR_NORMAL_COST;
+    }
+
+    /*? if >= 1.21 {*/
+    private static boolean isDoubleTradePrice(Holder<Enchantment> enchantment) {
+        return enchantment.is(EnchantmentTags.DOUBLE_TRADE_PRICE);
+    }
+    /*?} else {*/
+    /*private static boolean isDoubleTradePrice(Holder<Enchantment> enchantment) {
+        return enchantment.value().isTreasureOnly();
+    }
+    *//*?}*/
+
+    /*? if >= 26.1 {*/
+    private static void renderFirstBuyDecorations(GuiGraphicsExtractor context, Font font,
+            ItemStack stack, int x, int y, int color) {
+        if (color == COLOR_NORMAL_COST) {
+            context.itemDecorations(font, stack, x, y);
+            return;
+        }
+        var decoStack = stack.copy();
+        decoStack.setCount(1);
+        context.itemDecorations(font, decoStack, x, y);
+        String countText = String.valueOf(stack.getCount());
+        int textX = x + 19 - 2 - font.width(countText);
+        int textY = y + 6 + 3;
+        context.text(font, countText, textX, textY, color);
+    }
+    /*?} else {*/
+    /*private static void renderFirstBuyDecorations(GuiGraphics context, Font font,
+            ItemStack stack, int x, int y, int color) {
+        if (color == COLOR_NORMAL_COST) {
+            context.renderItemDecorations(font, stack, x, y);
+            return;
+        }
+        var decoStack = stack.copy();
+        decoStack.setCount(1);
+        context.renderItemDecorations(font, decoStack, x, y);
+        String countText = String.valueOf(stack.getCount());
+        int textX = x + 19 - 2 - font.width(countText);
+        int textY = y + 6 + 3;
+        context.drawString(font, countText, textX, textY, color);
+    }
+    *//*?}*/
 
     // from MerchantScreen
     /*? if >= 26.1 {*/

--- a/src/main/resources/assets/offershud/lang/en_us.json
+++ b/src/main/resources/assets/offershud/lang/en_us.json
@@ -3,6 +3,7 @@
   "text.autoconfig.offershud.option.enabled": "Enabled",
   "text.autoconfig.offershud.option.ignoreNoProfession": "Ignore villagers who do not have a profession",
   "text.autoconfig.offershud.option.suppressVillagerHeadRolling": "Suppress villager head rolling",
+  "text.autoconfig.offershud.option.highlightExtremePrices": "Highlight lowest / highest prices",
   "text.autoconfig.offershud.option.offsetX": "HUD Offset: X",
   "text.autoconfig.offershud.option.offsetY": "HUD Offset: Y",
   "text.autoconfig.offershud.option.scale": "HUD Scale",

--- a/src/main/resources/assets/offershud/lang/ja_jp.json
+++ b/src/main/resources/assets/offershud/lang/ja_jp.json
@@ -3,6 +3,7 @@
   "text.autoconfig.offershud.option.enabled": "有効",
   "text.autoconfig.offershud.option.ignoreNoProfession": "無職を無視する",
   "text.autoconfig.offershud.option.suppressVillagerHeadRolling": "村人の首振りを抑制する",
+  "text.autoconfig.offershud.option.highlightExtremePrices": "最安値・最高値を強調表示",
   "text.autoconfig.offershud.option.offsetX": "HUDのオフセット: X",
   "text.autoconfig.offershud.option.offsetY": "HUDのオフセット: Y",
   "text.autoconfig.offershud.option.scale": "HUDの倍率(大きさ)",

--- a/src/main/resources/assets/offershud/lang/ko_kr.json
+++ b/src/main/resources/assets/offershud/lang/ko_kr.json
@@ -3,6 +3,7 @@
   "text.autoconfig.offershud.option.enabled": "켜짐",
   "text.autoconfig.offershud.option.ignoreNoProfession": "직업이 없는 주민 무시",
   "text.autoconfig.offershud.option.suppressVillagerHeadRolling": "주민의 고개 흔들기 억제",
+  "text.autoconfig.offershud.option.highlightExtremePrices": "최저가 / 최고가 강조",
   "text.autoconfig.offershud.option.offsetX": "HUD 오프셋: X",
   "text.autoconfig.offershud.option.offsetY": "HUD 오프셋: Y",
   "text.autoconfig.offershud.option.scale": "HUD 크기",

--- a/src/main/resources/assets/offershud/lang/ru_ru.json
+++ b/src/main/resources/assets/offershud/lang/ru_ru.json
@@ -3,6 +3,7 @@
   "text.autoconfig.offershud.option.enabled": "Включено",
   "text.autoconfig.offershud.option.ignoreNoProfession": "Игнорировать жителей деревни, у которых нет профессии",
   "text.autoconfig.offershud.option.suppressVillagerHeadRolling": "Подавлять покачивание головой жителей",
+  "text.autoconfig.offershud.option.highlightExtremePrices": "Выделять самые низкие / высокие цены",
   "text.autoconfig.offershud.option.offsetX": "HUD Предложения: X",
   "text.autoconfig.offershud.option.offsetY": "HUD Предложения: Y",
   "text.autoconfig.offershud.option.scale": "HUD Масштаб",

--- a/src/main/resources/assets/offershud/lang/zh_cn.json
+++ b/src/main/resources/assets/offershud/lang/zh_cn.json
@@ -3,6 +3,7 @@
   "text.autoconfig.offershud.option.enabled": "启用",
   "text.autoconfig.offershud.option.ignoreNoProfession": "忽略无业村民",
   "text.autoconfig.offershud.option.suppressVillagerHeadRolling": "抑制村民摇头",
+  "text.autoconfig.offershud.option.highlightExtremePrices": "高亮显示最低价 / 最高价",
   "text.autoconfig.offershud.option.offsetX": "HUD X 方向偏移",
   "text.autoconfig.offershud.option.offsetY": "HUD Y 方向偏移",
   "text.autoconfig.offershud.option.scale": "HUD 缩放",


### PR DESCRIPTION
## Summary

Color buyA's emerald count green when a villager enchanted-book trade's base price is at the **minimum** of its level-dependent range, and red at the **maximum**, so the best and worst rolls are spottable without right-clicking each villager.

- Toggleable via the `highlightExtremePrices` config option (default on). Translations added for all 5 locales.
- Only buyA's stack-count color is swapped (durability/cooldown decorations preserved). buyB and the sell result don't vary, so they're left untouched.

## Pricing logic rationale

The enchanted-book base price is `2 + rand[0..4+10k] + 3k`, doubled for treasure (`#double_trade_price`) enchantments and capped at 64, giving the bounds `[2+3k, 6+13k]` for a fixed level k. Confirmed via decompilation:

- **1.20.6 / 1.21.x**: hardcoded in `VillagerTrades.EnchantBookForEmeralds.getOffer`.
- **26.1.x**: trades are data-driven (`ResourceKey<VillagerTrade>` + json). The cost flows through the loot function `EnchantRandomlyFunction` into the `ADDITIONAL_TRADE_COST` component, and `VillagerTrade.getOffer` applies the treasure x2. The trade json's `wants.count=0` makes the formula match 1.20.6/1.21.x.
- No public or private API exposes the range, and `ADDITIONAL_TRADE_COST` is removed from the result before the client receives it. The formula is therefore reproduced client-side (no AccessWidener needed; all required info is public API).
- Only the treasure check differs by version: 1.20.6 = `Enchantment.isTreasureOnly()`, 1.21+ = `EnchantmentTags.DOUBLE_TRADE_PRICE` (split via Stonecutter).

Example: Mending (k=1, treasure) -> range 10-38. A `baseCostA` of 10 shows green, 38 shows red.

## Limitations

- Only enchanted-book trades are handled (enchanted gear sold by armorer/toolsmith/weaponsmith uses a different cost formula and isn't covered).
- Only single-enchantment books are evaluated (multiple stored enchantments are skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)