### PR TITLE
Ignore the Windows reserved-name `nul` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ bin/
 # fabric
 
 run/
+
+# windows reserved-name junk (created when a cmd-style `>nul` redirect runs under Git Bash)
+
+/nul


### PR DESCRIPTION
A cmd-style `>nul` redirect run under Git Bash (MSYS) creates a regular file named `nul` in the repo root. Because `nul` is a Windows reserved device name, it can't be removed via Explorer or a plain `rm` (only via the `\?\` extended-length path). Add it to `.gitignore` so it never dirties `git status` if it reappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)