### PR TITLE
Add graphical HUD position editor

### DIFF
--- a/src/main/java/net/naari3/offershud/OffersHUD.java
+++ b/src/main/java/net/naari3/offershud/OffersHUD.java
@@ -46,6 +46,7 @@ public class OffersHUD implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         init();
+        net.naari3.offershud.config.ModConfigGui.registerGui();
     }
     //?}
 

--- a/src/main/java/net/naari3/offershud/OffersHUDNeoForge.java
+++ b/src/main/java/net/naari3/offershud/OffersHUDNeoForge.java
@@ -20,6 +20,8 @@ public class OffersHUDNeoForge {
         // Initialize common logic
         OffersHUD.init();
 
+        net.naari3.offershud.config.ModConfigGui.registerGui();
+
         // Register config screen (NeoForge native)
         //? if >= 1.21.11 {
         container.registerExtensionPoint(IConfigScreenFactory.class,

--- a/src/main/java/net/naari3/offershud/config/ModConfig.java
+++ b/src/main/java/net/naari3/offershud/config/ModConfig.java
@@ -19,6 +19,9 @@ public class ModConfig implements ConfigData {
     public int offsetY = 5;
     public float scale = 1.0f;
 
+    // Marker field: rendered as a button (see ModConfigGui) that opens the graphical position editor.
+    public boolean editPosition = false;
+
     public enum Alignment {
         TOP_LEFT, TOP_RIGHT, BOTTOM_LEFT, BOTTOM_RIGHT;
         public boolean isRight() {

--- a/src/main/java/net/naari3/offershud/config/ModConfigGui.java
+++ b/src/main/java/net/naari3/offershud/config/ModConfigGui.java
@@ -1,0 +1,34 @@
+package net.naari3.offershud.config;
+
+import java.util.Collections;
+
+/*? if >= 1.21.11 {*/
+import me.shedaniel.autoconfig.AutoConfigClient;
+/*?} else {*/
+/*import me.shedaniel.autoconfig.AutoConfig;
+*//*?}*/
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import net.minecraft.network.chat.Component;
+
+/**
+ * Registers a custom Cloth Config GUI provider so that the {@code editPosition}
+ * marker field is rendered as a button that opens the graphical position editor.
+ * Client-only; must be called once during client init.
+ */
+public final class ModConfigGui {
+    private ModConfigGui() {
+    }
+
+    public static void registerGui() {
+        /*? if >= 1.21.11 {*/
+        AutoConfigClient.getGuiRegistry(ModConfig.class).registerPredicateProvider(
+        /*?} else {*/
+        /*AutoConfig.getGuiRegistry(ModConfig.class).registerPredicateProvider(
+        *//*?}*/
+                (i18n, field, config, defaults, registry) ->
+                        Collections.<AbstractConfigListEntry>singletonList(
+                                new PositionButtonEntry(
+                                        Component.translatable("text.autoconfig.offershud.option.editPosition.button"))),
+                field -> field.getName().equals("editPosition"));
+    }
+}

--- a/src/main/java/net/naari3/offershud/config/PositionButtonEntry.java
+++ b/src/main/java/net/naari3/offershud/config/PositionButtonEntry.java
@@ -1,0 +1,99 @@
+package net.naari3.offershud.config;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import org.jetbrains.annotations.Nullable;
+
+import me.shedaniel.clothconfig2.api.AbstractConfigListEntry;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ComponentPath;
+/*? if >= 26.1 {*/
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+/*?} else {*/
+/*import net.minecraft.client.gui.GuiGraphics;
+*//*?}*/
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.navigation.FocusNavigationEvent;
+import net.minecraft.network.chat.Component;
+import net.naari3.offershud.gui.OffersPositionScreen;
+
+/**
+ * A Cloth Config list entry that renders a single button which opens the
+ * graphical HUD position editor ({@link OffersPositionScreen}).
+ */
+public class PositionButtonEntry extends AbstractConfigListEntry<Object> {
+    private final Button button;
+    private final List<Button> widgets;
+
+    public PositionButtonEntry(Component buttonText) {
+        super(Component.literal("editPosition"), false);
+        this.button = Button.builder(buttonText, b -> {
+            Minecraft mc = Minecraft.getInstance();
+            mc.setScreen(new OffersPositionScreen(mc.screen));
+        }).bounds(0, 0, 150, 20).build();
+        this.widgets = Collections.singletonList(button);
+    }
+
+    @Override
+    public int getItemHeight() {
+        return 24;
+    }
+
+    @Override
+    public Object getValue() {
+        return null;
+    }
+
+    @Override
+    public Optional<Object> getDefaultValue() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Iterator<String> getSearchTags() {
+        return Collections.emptyIterator();
+    }
+
+    @Override
+    @Nullable
+    public ComponentPath nextFocusPath(FocusNavigationEvent event) {
+        return button.nextFocusPath(event);
+    }
+
+    @Override
+    public List<? extends NarratableEntry> narratables() {
+        return widgets;
+    }
+
+    @Override
+    public List<? extends GuiEventListener> children() {
+        return widgets;
+    }
+
+    /*? if >= 26.1 {*/
+    @Override
+    public void extractRenderState(GuiGraphicsExtractor graphics, int index, int y, int x, int entryWidth,
+            int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
+        super.extractRenderState(graphics, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
+        button.setX(x);
+        button.setY(y);
+        button.setWidth(Math.min(entryWidth, 200));
+        button.extractRenderState(graphics, mouseX, mouseY, delta);
+    }
+    /*?} else {*/
+    /*@Override
+    public void render(GuiGraphics graphics, int index, int y, int x, int entryWidth,
+            int entryHeight, int mouseX, int mouseY, boolean isHovered, float delta) {
+        super.render(graphics, index, y, x, entryWidth, entryHeight, mouseX, mouseY, isHovered, delta);
+        button.setX(x);
+        button.setY(y);
+        button.setWidth(Math.min(entryWidth, 200));
+        button.render(graphics, mouseX, mouseY, delta);
+    }
+    *//*?}*/
+}

--- a/src/main/java/net/naari3/offershud/gui/OffersPositionScreen.java
+++ b/src/main/java/net/naari3/offershud/gui/OffersPositionScreen.java
@@ -1,0 +1,337 @@
+package net.naari3.offershud.gui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import me.shedaniel.autoconfig.AutoConfig;
+/*? if >= 1.21.11 {*/
+import me.shedaniel.autoconfig.AutoConfigClient;
+/*?}*/
+import me.shedaniel.clothconfig2.gui.AbstractConfigScreen;
+/*? if >= 26.1 {*/
+import net.minecraft.client.gui.GuiGraphicsExtractor;
+/*?} else {*/
+/*import net.minecraft.client.gui.GuiGraphics;
+*//*?}*/
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+/*? if >= 1.21.9 {*/
+import net.minecraft.client.input.KeyEvent;
+import net.minecraft.client.input.MouseButtonEvent;
+/*?}*/
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
+import net.minecraft.world.item.trading.ItemCost;
+import net.minecraft.world.item.trading.MerchantOffer;
+import net.naari3.offershud.MerchantInfo;
+import net.naari3.offershud.OffersHUD;
+import net.naari3.offershud.config.ModConfig;
+import net.naari3.offershud.renderer.OffersHUDRenderer;
+
+public class OffersPositionScreen extends Screen {
+    // GLFW key codes
+    private static final int KEY_RIGHT = 262;
+    private static final int KEY_LEFT = 263;
+    private static final int KEY_DOWN = 264;
+    private static final int KEY_UP = 265;
+    private static final int MOD_SHIFT = 0x0001;
+
+    private final Screen parent;
+    private final ModConfig config;
+    private List<MerchantOffer> previewOffers;
+
+    // working values (committed to config only on Done)
+    private ModConfig.Alignment workAlignment;
+    private int workOffsetX;
+    private int workOffsetY;
+    private float workScale;
+
+    // current HUD top-left in scaled-gui pixels
+    private float curX;
+    private float curY;
+
+    private boolean dragging = false;
+    private double grabDX;
+    private double grabDY;
+
+    public OffersPositionScreen(Screen parent) {
+        super(Component.translatable("offershud.screen.position.title"));
+        this.parent = parent;
+        this.config = OffersHUD.getConfig();
+        this.workAlignment = config.alignment;
+        this.workOffsetX = config.offsetX;
+        this.workOffsetY = config.offsetY;
+        this.workScale = config.scale;
+    }
+
+    @Override
+    protected void init() {
+        List<MerchantOffer> live = MerchantInfo.getInfo().getOffers();
+        this.previewOffers = (live != null && !live.isEmpty()) ? live : sampleOffers();
+        recomputeTopLeftFromWork();
+
+        int cx = this.width / 2;
+        int by = this.height - 28;
+
+        this.addRenderableWidget(Button.builder(Component.literal("-"), b -> {
+            workScale = Math.max(0.25f, Math.round((workScale - 0.25f) * 100f) / 100f);
+            recomputeTopLeftFromWork();
+        }).bounds(cx - 154, by, 20, 20).build());
+
+        this.addRenderableWidget(Button.builder(Component.literal("+"), b -> {
+            workScale = Math.min(3.0f, Math.round((workScale + 0.25f) * 100f) / 100f);
+            recomputeTopLeftFromWork();
+        }).bounds(cx - 132, by, 20, 20).build());
+
+        this.addRenderableWidget(Button.builder(Component.translatable("offershud.screen.position.reset"), b -> {
+            workAlignment = ModConfig.Alignment.TOP_LEFT;
+            workOffsetX = 5;
+            workOffsetY = 5;
+            workScale = 1.0f;
+            recomputeTopLeftFromWork();
+        }).bounds(cx - 108, by, 100, 20).build());
+
+        this.addRenderableWidget(Button.builder(CommonComponents.GUI_DONE, b -> {
+            config.alignment = workAlignment;
+            config.offsetX = workOffsetX;
+            config.offsetY = workOffsetY;
+            config.scale = workScale;
+            AutoConfig.getConfigHolder(ModConfig.class).save();
+            // The parent Cloth Config screen caches its entry widgets with the values
+            // they had when built, so it would still show the old values after we save.
+            // Rebuild a fresh config screen so the saved values are reflected immediately.
+            Screen rebuilt = rebuiltConfigScreen(parent);
+            this.minecraft.setScreen(rebuilt != null ? rebuilt : parent);
+        }).bounds(cx - 4, by, 100, 20).build());
+
+        this.addRenderableWidget(Button.builder(CommonComponents.GUI_CANCEL, b -> onClose())
+                .bounds(cx + 100, by, 100, 20).build());
+    }
+
+    private static List<MerchantOffer> sampleOffers() {
+        List<MerchantOffer> list = new ArrayList<>();
+        list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 5), Optional.empty(),
+                new ItemStack(Items.DIAMOND), 12, 5, 0.05f));
+        list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 20), Optional.of(new ItemCost(Items.BOOK)),
+                new ItemStack(Items.ENCHANTED_BOOK), 3, 10, 0.2f));
+        list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 1), Optional.empty(),
+                new ItemStack(Items.BREAD, 6), 16, 1, 0.05f));
+        return list;
+    }
+
+    private float scaledW() {
+        return OffersHUDRenderer.calcWidth(previewOffers, this.font) * workScale;
+    }
+
+    private float scaledH() {
+        return OffersHUDRenderer.calcHeight(previewOffers) * workScale;
+    }
+
+    private void recomputeTopLeftFromWork() {
+        float sW = scaledW();
+        float sH = scaledH();
+        curX = workAlignment.isRight() ? this.width - sW - workOffsetX : workOffsetX;
+        curY = workAlignment.isBottom() ? this.height - sH - workOffsetY : workOffsetY;
+    }
+
+    private void snapToCorner() {
+        float sW = scaledW();
+        float sH = scaledH();
+        float centerX = curX + sW / 2f;
+        float centerY = curY + sH / 2f;
+        boolean right = centerX >= this.width / 2.0f;
+        boolean bottom = centerY >= this.height / 2.0f;
+        workAlignment = right
+                ? (bottom ? ModConfig.Alignment.BOTTOM_RIGHT : ModConfig.Alignment.TOP_RIGHT)
+                : (bottom ? ModConfig.Alignment.BOTTOM_LEFT : ModConfig.Alignment.TOP_LEFT);
+        workOffsetX = Math.max(0, Math.round(right ? this.width - sW - curX : curX));
+        workOffsetY = Math.max(0, Math.round(bottom ? this.height - sH - curY : curY));
+        recomputeTopLeftFromWork();
+    }
+
+    private boolean inBox(double mx, double my) {
+        float sW = scaledW();
+        float sH = scaledH();
+        return mx >= curX && mx <= curX + sW && my >= curY && my <= curY + sH;
+    }
+
+    private int boxColor() {
+        return dragging ? 0x6055FF55 : 0x3055FF55;
+    }
+
+    /*? if >= 26.1 {*/
+    @Override
+    public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float partialTick) {
+        context.fill(0, 0, context.guiWidth(), context.guiHeight(), 0x88000000);
+        super.extractRenderState(context, mouseX, mouseY, partialTick);
+        context.centeredText(this.font, this.title.getString(), this.width / 2, 10, 0xFFFFFFFF);
+        context.centeredText(this.font, Component.translatable("offershud.screen.position.hint").getString(),
+                this.width / 2, 22, 0xFFAAAAAA);
+        context.centeredText(this.font, String.format("scale: %.2f  /  %s", workScale, workAlignment.name()),
+                this.width / 2, 34, 0xFFAAAAAA);
+        float sW = scaledW();
+        float sH = scaledH();
+        context.fill(Math.round(curX) - 1, Math.round(curY) - 1, Math.round(curX + sW) + 1, Math.round(curY + sH) + 1,
+                boxColor());
+        OffersHUDRenderer.renderOffers(context, this.font, previewOffers, curX, curY, workScale,
+                config.highlightExtremePrices);
+    }
+    /*?} else {*/
+    /*@Override
+    public void render(GuiGraphics context, int mouseX, int mouseY, float partialTick) {
+        context.fill(0, 0, this.width, this.height, 0x88000000);
+        super.render(context, mouseX, mouseY, partialTick);
+        context.drawCenteredString(this.font, this.title.getString(), this.width / 2, 10, 0xFFFFFFFF);
+        context.drawCenteredString(this.font, Component.translatable("offershud.screen.position.hint").getString(),
+                this.width / 2, 22, 0xFFAAAAAA);
+        context.drawCenteredString(this.font, String.format("scale: %.2f  /  %s", workScale, workAlignment.name()),
+                this.width / 2, 34, 0xFFAAAAAA);
+        float sW = scaledW();
+        float sH = scaledH();
+        context.fill(Math.round(curX) - 1, Math.round(curY) - 1, Math.round(curX + sW) + 1, Math.round(curY + sH) + 1,
+                boxColor());
+        OffersHUDRenderer.renderOffers(context, this.font, previewOffers, curX, curY, workScale,
+                config.highlightExtremePrices);
+    }
+    *//*?}*/
+
+    /*? if >= 1.21.9 {*/
+    @Override
+    public boolean mouseClicked(MouseButtonEvent event, boolean doubled) {
+        if (super.mouseClicked(event, doubled)) {
+            return true;
+        }
+        if (event.button() == 0 && inBox(event.x(), event.y())) {
+            dragging = true;
+            grabDX = event.x() - curX;
+            grabDY = event.y() - curY;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean mouseDragged(MouseButtonEvent event, double dragX, double dragY) {
+        if (dragging) {
+            curX = (float) (event.x() - grabDX);
+            curY = (float) (event.y() - grabDY);
+            return true;
+        }
+        return super.mouseDragged(event, dragX, dragY);
+    }
+
+    @Override
+    public boolean mouseReleased(MouseButtonEvent event) {
+        if (dragging && event.button() == 0) {
+            dragging = false;
+            snapToCorner();
+            return true;
+        }
+        return super.mouseReleased(event);
+    }
+
+    @Override
+    public boolean keyPressed(KeyEvent event) {
+        int step = (event.modifiers() & MOD_SHIFT) != 0 ? 10 : 1;
+        boolean handled = true;
+        switch (event.key()) {
+            case KEY_RIGHT -> curX += step;
+            case KEY_LEFT -> curX -= step;
+            case KEY_DOWN -> curY += step;
+            case KEY_UP -> curY -= step;
+            default -> handled = false;
+        }
+        if (handled) {
+            snapToCorner();
+            return true;
+        }
+        return super.keyPressed(event);
+    }
+    /*?} else {*/
+    /*@Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (super.mouseClicked(mouseX, mouseY, button)) {
+            return true;
+        }
+        if (button == 0 && inBox(mouseX, mouseY)) {
+            dragging = true;
+            grabDX = mouseX - curX;
+            grabDY = mouseY - curY;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean mouseDragged(double mouseX, double mouseY, int button, double dragX, double dragY) {
+        if (dragging) {
+            curX = (float) (mouseX - grabDX);
+            curY = (float) (mouseY - grabDY);
+            return true;
+        }
+        return super.mouseDragged(mouseX, mouseY, button, dragX, dragY);
+    }
+
+    @Override
+    public boolean mouseReleased(double mouseX, double mouseY, int button) {
+        if (dragging && button == 0) {
+            dragging = false;
+            snapToCorner();
+            return true;
+        }
+        return super.mouseReleased(mouseX, mouseY, button);
+    }
+
+    @Override
+    public boolean keyPressed(int keyCode, int scanCode, int modifiers) {
+        int step = (modifiers & MOD_SHIFT) != 0 ? 10 : 1;
+        boolean handled = true;
+        switch (keyCode) {
+            case KEY_RIGHT -> curX += step;
+            case KEY_LEFT -> curX -= step;
+            case KEY_DOWN -> curY += step;
+            case KEY_UP -> curY -= step;
+            default -> handled = false;
+        }
+        if (handled) {
+            snapToCorner();
+            return true;
+        }
+        return super.keyPressed(keyCode, scanCode, modifiers);
+    }
+    *//*?}*/
+
+    @Override
+    public void onClose() {
+        this.minecraft.setScreen(parent);
+    }
+
+    /**
+     * If this editor was opened from a Cloth Config screen, build a fresh instance of it
+     * so that just-saved config values are shown (Cloth caches entry widgets and does not
+     * react to external config changes). Returns {@code null} when the parent is not a
+     * Cloth Config screen or its parent reference can't be read, so the caller falls back
+     * to reusing the existing (stale) parent instead of breaking navigation.
+     */
+    private Screen rebuiltConfigScreen(Screen current) {
+        if (!(current instanceof AbstractConfigScreen)) {
+            return null;
+        }
+        try {
+            java.lang.reflect.Field parentField = AbstractConfigScreen.class.getDeclaredField("parent");
+            parentField.setAccessible(true);
+            Screen grandparent = (Screen) parentField.get(current);
+            /*? if >= 1.21.11 {*/
+            return AutoConfigClient.getConfigScreen(ModConfig.class, grandparent).get();
+            /*?} else {*/
+            /*return AutoConfig.getConfigScreen(ModConfig.class, grandparent).get();
+            *//*?}*/
+        } catch (Exception e) {
+            OffersHUD.logger.warn("Failed to rebuild config screen after position edit", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
+++ b/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
@@ -107,12 +107,6 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
         RenderSystem.setShaderTexture(0, AbstractContainerScreen.INVENTORY_LOCATION);
         *//*?}*/
 
-        /*? if >= 26.1 {*/
-        var modelMatrices = context.pose();
-        /*?} else {*/
-        /*var modelMatrices = context.pose();
-        *//*?}*/
-
         MerchantInfo.getInfo().getLastId().ifPresent(lastId -> {
             var offers = MerchantInfo.getInfo().getOffers();
 
@@ -132,79 +126,90 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
                     screenHeight - (calcHeight(offers) * scale) - config.offsetY :
                     config.offsetY;
 
-            /*? if >= 1.21.6 {*/
-            modelMatrices.pushMatrix();
-            /*?} else {*/
-            /*modelMatrices.pushPose();
-            *//*?}*/;
-
-            /*? if >= 1.21.6 {*/
-            modelMatrices.translate(translateX, translateY);
-            /*?} else {*/
-            /*modelMatrices.translate(translateX, translateY, 1.0);
-            *//*?}*/;
-
-            /*? if >= 1.21.6 {*/
-            modelMatrices.scale(scale, scale);
-            /*?} else {*/
-            /*modelMatrices.scale(scale, scale, 1.0f);
-            *//*?}*/;
-
-            //? if <1.21.3
-            /*RenderSystem.applyModelViewMatrix();*/
-
-            var i = 0;
-
-            for (MerchantOffer offer : offers) {
-                var baseX = 0;
-                var baseY = 0 + i * 20;
-
-                var firstBuy = offer.getCostA().copy();
-                var secondBuy = offer.getCostB().copy();
-                var sell = offer.getResult().copy();
-
-                int firstBuyColor = config.highlightExtremePrices
-                        ? computeExtremePriceColor(offer)
-                        : COLOR_NORMAL_COST;
-
-                /*? if >= 26.1 {*/
-                context.item(firstBuy, baseX, baseY);
-                renderFirstBuyDecorations(context, textRenderer, firstBuy, baseX, baseY, firstBuyColor);
-
-                context.item(secondBuy, baseX + 20, baseY);
-                context.itemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
-
-                context.item(sell, baseX + 53, baseY);
-                context.itemDecorations(textRenderer, sell, baseX + 53, baseY);
-                /*?} else {*/
-                /*context.renderItem(firstBuy, baseX, baseY);
-                renderFirstBuyDecorations(context, textRenderer, firstBuy, baseX, baseY, firstBuyColor);
-
-                context.renderItem(secondBuy, baseX + 20, baseY);
-                context.renderItemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
-
-                context.renderItem(sell, baseX + 53, baseY);
-                context.renderItemDecorations(textRenderer, sell, baseX + 53, baseY);
-                *//*?}*/
-
-                this.renderArrow(context, offer, baseX + -20, baseY);
-
-                var enchantments = getEnchantmentText(offer);
-
-                /*? if >= 26.1 {*/
-                context.text(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
-                /*?} else {*/
-                /*context.drawString(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
-                *//*?}*/
-                i += 1;
-            }
-
-            /*? if >= 1.21.6 {*/
-            modelMatrices.popMatrix();
-            /*?} else {*/
-            /*modelMatrices.popPose();
-            *//*?}*/;
+            renderOffers(context, textRenderer, offers, translateX, translateY, scale, config.highlightExtremePrices);
         });
+    }
+
+    /*? if >= 26.1 {*/
+    public static void renderOffers(GuiGraphicsExtractor context, Font textRenderer, List<MerchantOffer> offers, float originX, float originY, float scale, boolean highlightExtremePrices) {
+        var modelMatrices = context.pose();
+    /*?} else {*/
+    /*public static void renderOffers(GuiGraphics context, Font textRenderer, List<MerchantOffer> offers, float originX, float originY, float scale, boolean highlightExtremePrices) {
+        var modelMatrices = context.pose();
+    *//*?}*/
+
+        /*? if >= 1.21.6 {*/
+        modelMatrices.pushMatrix();
+        /*?} else {*/
+        /*modelMatrices.pushPose();
+        *//*?}*/;
+
+        /*? if >= 1.21.6 {*/
+        modelMatrices.translate(originX, originY);
+        /*?} else {*/
+        /*modelMatrices.translate(originX, originY, 1.0);
+        *//*?}*/;
+
+        /*? if >= 1.21.6 {*/
+        modelMatrices.scale(scale, scale);
+        /*?} else {*/
+        /*modelMatrices.scale(scale, scale, 1.0f);
+        *//*?}*/;
+
+        //? if <1.21.3
+        /*RenderSystem.applyModelViewMatrix();*/
+
+        var i = 0;
+
+        for (MerchantOffer offer : offers) {
+            var baseX = 0;
+            var baseY = 0 + i * 20;
+
+            var firstBuy = offer.getCostA().copy();
+            var secondBuy = offer.getCostB().copy();
+            var sell = offer.getResult().copy();
+
+            int firstBuyColor = highlightExtremePrices
+                    ? computeExtremePriceColor(offer)
+                    : COLOR_NORMAL_COST;
+
+            /*? if >= 26.1 {*/
+            context.item(firstBuy, baseX, baseY);
+            renderFirstBuyDecorations(context, textRenderer, firstBuy, baseX, baseY, firstBuyColor);
+
+            context.item(secondBuy, baseX + 20, baseY);
+            context.itemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
+
+            context.item(sell, baseX + 53, baseY);
+            context.itemDecorations(textRenderer, sell, baseX + 53, baseY);
+            /*?} else {*/
+            /*context.renderItem(firstBuy, baseX, baseY);
+            renderFirstBuyDecorations(context, textRenderer, firstBuy, baseX, baseY, firstBuyColor);
+
+            context.renderItem(secondBuy, baseX + 20, baseY);
+            context.renderItemDecorations(textRenderer, secondBuy, baseX + 20, baseY);
+
+            context.renderItem(sell, baseX + 53, baseY);
+            context.renderItemDecorations(textRenderer, sell, baseX + 53, baseY);
+            *//*?}*/
+
+            renderArrow(context, offer, baseX + -20, baseY);
+
+            var enchantments = getEnchantmentText(offer);
+
+            /*? if >= 26.1 {*/
+            context.text(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
+            /*?} else {*/
+            /*context.drawString(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
+            *//*?}*/
+            i += 1;
+        }
+
+        /*? if >= 1.21.6 {*/
+        modelMatrices.popMatrix();
+        /*?} else {*/
+        /*modelMatrices.popPose();
+        *//*?}*/;
     }
 
     private static final int COLOR_NORMAL_COST = 0xFFFFFFFF;
@@ -283,9 +288,9 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
 
     // from MerchantScreen
     /*? if >= 26.1 {*/
-    private void renderArrow(GuiGraphicsExtractor context, MerchantOffer tradeOffer, int x, int y) {
+    private static void renderArrow(GuiGraphicsExtractor context, MerchantOffer tradeOffer, int x, int y) {
     /*?} else {*/
-    /*private void renderArrow(GuiGraphics context, MerchantOffer tradeOffer, int x, int y) {
+    /*private static void renderArrow(GuiGraphics context, MerchantOffer tradeOffer, int x, int y) {
     *//*?}*/
         if (tradeOffer.isOutOfStock()) {
             //? if >=1.21.6 {
@@ -325,7 +330,7 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
         }
     }
 
-    private String getEnchantmentText(MerchantOffer offer) {
+    private static String getEnchantmentText(MerchantOffer offer) {
         List<String> enchantments = new ArrayList<>();
 
         /*? if >= 1.21 {*/
@@ -356,7 +361,7 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
         return String.join(", ", enchantments);
     }
 
-    private int calcWidth(List<MerchantOffer> offers, Font textRenderer) {
+    public static int calcWidth(List<MerchantOffer> offers, Font textRenderer) {
         int maxWidth = 0;
         for (var offer : offers) {
             var enchantments = getEnchantmentText(offer);
@@ -368,7 +373,7 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
         return maxWidth;
     }
 
-    private int calcHeight(List<MerchantOffer> offers) {
+    public static int calcHeight(List<MerchantOffer> offers) {
         return offers.size() * 20;
     }
 }

--- a/src/main/resources/assets/offershud/lang/en_us.json
+++ b/src/main/resources/assets/offershud/lang/en_us.json
@@ -11,5 +11,10 @@
   "text.autoconfig.offershud.option.alignment.TOP_LEFT": "Top Left",
   "text.autoconfig.offershud.option.alignment.TOP_RIGHT": "Top Right",
   "text.autoconfig.offershud.option.alignment.BOTTOM_LEFT": "Bottom Left",
-  "text.autoconfig.offershud.option.alignment.BOTTOM_RIGHT": "Bottom Right"
+  "text.autoconfig.offershud.option.alignment.BOTTOM_RIGHT": "Bottom Right",
+  "text.autoconfig.offershud.option.editPosition": "Edit HUD Position",
+  "text.autoconfig.offershud.option.editPosition.button": "Edit Position…",
+  "offershud.screen.position.title": "Edit HUD Position",
+  "offershud.screen.position.hint": "Drag the HUD to move it. Arrow keys to nudge (Shift = 10px).",
+  "offershud.screen.position.reset": "Reset"
 }

--- a/src/main/resources/assets/offershud/lang/ja_jp.json
+++ b/src/main/resources/assets/offershud/lang/ja_jp.json
@@ -11,5 +11,10 @@
   "text.autoconfig.offershud.option.alignment.TOP_LEFT": "左上",
   "text.autoconfig.offershud.option.alignment.TOP_RIGHT": "右上",
   "text.autoconfig.offershud.option.alignment.BOTTOM_LEFT": "左下",
-  "text.autoconfig.offershud.option.alignment.BOTTOM_RIGHT": "右下"
+  "text.autoconfig.offershud.option.alignment.BOTTOM_RIGHT": "右下",
+  "text.autoconfig.offershud.option.editPosition": "HUD位置を編集",
+  "text.autoconfig.offershud.option.editPosition.button": "位置を編集…",
+  "offershud.screen.position.title": "HUD位置の編集",
+  "offershud.screen.position.hint": "HUDをドラッグして移動。矢印キーで微調整(Shiftで10px)。",
+  "offershud.screen.position.reset": "リセット"
 }

--- a/versions/1.21.9-neoforge/gradle.properties
+++ b/versions/1.21.9-neoforge/gradle.properties
@@ -6,6 +6,6 @@ parchment_version=1.21.9:2025.10.05
 neoforge_version=21.9.16-beta
 neoforge_version_range=[21.9,)
 loader_version_range=[4,)
-cloth_config_version=19.0.147
+cloth_config_version=20.0.149
 
 release-curse-versions = Minecraft 1.21:1.21.9


### PR DESCRIPTION
## What

Adds an editor screen that lets you **drag the villager trade HUD to reposition it** instead of typing offset/alignment values into the config.

- New `OffersPositionScreen`: drag the HUD preview to move it, release it near a corner to auto-snap `alignment`, `scale` `-`/`+` buttons, arrow-key nudging (Shift for 10px), and Reset / Done / Cancel
- Opened from an "Edit Position" button added to the config screen (Cloth Config / NeoForge Mods)
- Keeps the existing coordinate model (`alignment` + `offsetX/offsetY` + `scale`) for backward compatibility. The HUD and the editor share one render core, `renderOffers`
- Supports MC 1.20.6–26.1 on Fabric/NeoForge, branching the rendering (`>=26.1`), input (`>=1.21.9`), and cloth GuiRegistry (`>=1.21.11`) generations via stonecutter

Inspired by SpeedRunIGT's timer position editor.

## Drive-by

Bumps cloth-config for `1.21.9-neoforge` from `19.0.147` to `20.0.149`. NeoForge 21.9 turned `FMLEnvironment.dist` from a field into a method, so 19.x crashed at mod construction with `NoSuchFieldError`. 20.0.149 is the matching release (already used by 1.21.10-neoforge).

## Test

- `compileJava` passes for all 18 targets (1.20.6–26.1 × Fabric/NeoForge)
- Launched and verified in-game on 26.1 (f/n), 1.20.6 (f/n), 1.21.9 (f), 1.21.11 (f/n) — covering every combination of rendering (extract ↔ GuiGraphics), input (Event ↔ primitive), and GuiRegistry (AutoConfigClient ↔ AutoConfig)
- Found and fixed during testing: the `<26.1` editor triggered a double-blur exception by calling `renderBackground` explicitly — switched to a manual `fill`

### Known issue (out of scope)

The `1.21.9-neoforge` Mods-screen crash (`ModListScreen.tick` sorting an immutable list) is a bug in NeoForge 21.9.16-beta itself. NeoForge 21.9 has no stable release (all beta), so this awaits an upstream fix. It is unrelated to this feature or cloth (the game launches fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)