### PR TITLE
Show real item icons in Edit Position preview (MC 26.1+)

### DIFF
--- a/src/main/java/net/naari3/offershud/OffersHUD.java
+++ b/src/main/java/net/naari3/offershud/OffersHUD.java
@@ -1,11 +1,15 @@
 package net.naari3.offershud;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.core.Holder;
+import net.minecraft.world.item.trading.ItemCost;
 import net.minecraft.world.item.trading.Merchant;
+import net.minecraft.world.item.trading.MerchantOffer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -40,6 +44,8 @@ public class OffersHUD implements ClientModInitializer {
     public static final String MODID = "offershud";
     public static final Logger logger = LogManager.getLogger(MODID);
     public static boolean openWindow = false;
+    public static List<MerchantOffer> SAMPLE_OFFERS = new ArrayList<>();
+    public static final List<String> SAMPLE_ENCHANT_TEXTS = List.of("", "Fortune III", "");
     private static ModConfig config;
 
     //? if fabric {
@@ -104,7 +110,55 @@ public class OffersHUD implements ClientModInitializer {
         });
 
         platform.registerHudRenderer(new OffersHUDRenderer());
+
+        SAMPLE_OFFERS = buildSampleOffers();
+        logger.info("Pre-generated {} sample offer(s)", SAMPLE_OFFERS.size());
     }
+
+    public static List<MerchantOffer> buildSampleOffers() {
+        try {
+            List<MerchantOffer> list = new ArrayList<>();
+            /*? if >= 26.2 {*/
+            var pred = net.minecraft.core.component.DataComponentExactPredicate.EMPTY;
+            // Holder.direct avoids "Components not bound yet" on the title screen,
+            // but ITEM_MODEL must be included so the renderer can find the model.
+            java.util.function.Function<net.minecraft.world.item.Item, net.minecraft.core.Holder<net.minecraft.world.item.Item>> h = item ->
+                net.minecraft.core.Holder.direct(item,
+                    net.minecraft.core.component.DataComponentMap.builder()
+                        .set(net.minecraft.core.component.DataComponents.ITEM_MODEL,
+                            net.minecraft.core.registries.BuiltInRegistries.ITEM.getKey(item))
+                        .build());
+            var emerald = h.apply(Items.EMERALD);
+            var book = h.apply(Items.BOOK);
+            var diamond = h.apply(Items.DIAMOND);
+            var enchBook = h.apply(Items.ENCHANTED_BOOK);
+            var bread = h.apply(Items.BREAD);
+            list.add(new MerchantOffer(new ItemCost(emerald, 5, pred), Optional.empty(),
+                    new ItemStack(diamond, 1), 12, 5, 0.05f));
+            list.add(new MerchantOffer(new ItemCost(emerald, 20, pred), Optional.of(new ItemCost(book, 1, pred)),
+                    new ItemStack(enchBook, 1), 3, 10, 0.2f));
+            list.add(new MerchantOffer(new ItemCost(emerald, 1, pred), Optional.empty(),
+                    new ItemStack(bread, 6), 16, 1, 0.05f));
+            /*?} else {*/
+            /*list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 5), Optional.empty(),
+                    new ItemStack(Items.DIAMOND), 12, 5, 0.05f));
+            list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 20), Optional.of(new ItemCost(Items.BOOK)),
+                    buildEnchantedBook(), 3, 10, 0.2f));
+            list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 1), Optional.empty(),
+                    new ItemStack(Items.BREAD, 6), 16, 1, 0.05f));
+            *//*?}*/
+            return list;
+        } catch (Exception e) {
+            logger.debug("buildSampleOffers failed: {}", e.getMessage());
+            return new ArrayList<>();
+        }
+    }
+
+    /*? if < 26.2 {*/
+    /*private static ItemStack buildEnchantedBook() {
+        return new ItemStack(Items.ENCHANTED_BOOK);
+    }
+    *//*?}*/
 
     private static Entity getUpdatableEntity(Minecraft mc) {
         if (OffersHUD.getOpenWindow()) {

--- a/src/main/java/net/naari3/offershud/OffersHUD.java
+++ b/src/main/java/net/naari3/offershud/OffersHUD.java
@@ -118,7 +118,7 @@ public class OffersHUD implements ClientModInitializer {
     public static List<MerchantOffer> buildSampleOffers() {
         try {
             List<MerchantOffer> list = new ArrayList<>();
-            /*? if >= 26.2 {*/
+            /*? if >= 26.1 {*/
             var pred = net.minecraft.core.component.DataComponentExactPredicate.EMPTY;
             // Holder.direct avoids "Components not bound yet" on the title screen,
             // but ITEM_MODEL must be included so the renderer can find the model.
@@ -154,7 +154,7 @@ public class OffersHUD implements ClientModInitializer {
         }
     }
 
-    /*? if < 26.2 {*/
+    /*? if < 26.1 {*/
     /*private static ItemStack buildEnchantedBook() {
         return new ItemStack(Items.ENCHANTED_BOOK);
     }

--- a/src/main/java/net/naari3/offershud/gui/OffersPositionScreen.java
+++ b/src/main/java/net/naari3/offershud/gui/OffersPositionScreen.java
@@ -1,8 +1,6 @@
 package net.naari3.offershud.gui;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 import me.shedaniel.autoconfig.AutoConfig;
 /*? if >= 1.21.11 {*/
@@ -22,9 +20,6 @@ import net.minecraft.client.input.MouseButtonEvent;
 /*?}*/
 import net.minecraft.network.chat.CommonComponents;
 import net.minecraft.network.chat.Component;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
-import net.minecraft.world.item.trading.ItemCost;
 import net.minecraft.world.item.trading.MerchantOffer;
 import net.naari3.offershud.MerchantInfo;
 import net.naari3.offershud.OffersHUD;
@@ -42,6 +37,8 @@ public class OffersPositionScreen extends Screen {
     private final Screen parent;
     private final ModConfig config;
     private List<MerchantOffer> previewOffers = new java.util.ArrayList<>();
+    private List<String> previewEnchantTexts = null;
+    private boolean sampleFailed = false;
 
     // working values (committed to config only on Done)
     private ModConfig.Alignment workAlignment;
@@ -69,8 +66,7 @@ public class OffersPositionScreen extends Screen {
 
     @Override
     protected void init() {
-        List<MerchantOffer> live = MerchantInfo.getInfo().getOffers();
-        this.previewOffers = (live != null && !live.isEmpty()) ? live : sampleOffers();
+        ensurePreviewOffers();
         recomputeTopLeftFromWork();
 
         int cx = this.width / 2;
@@ -115,27 +111,58 @@ public class OffersPositionScreen extends Screen {
                 .bounds(cx + 100, by, 100, 20).build());
     }
 
-    private static List<MerchantOffer> sampleOffers() {
-        try {
-            List<MerchantOffer> list = new ArrayList<>();
-            list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 5), Optional.empty(),
-                    new ItemStack(Items.DIAMOND), 12, 5, 0.05f));
-            list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 20), Optional.of(new ItemCost(Items.BOOK)),
-                    new ItemStack(Items.ENCHANTED_BOOK), 3, 10, 0.2f));
-            list.add(new MerchantOffer(new ItemCost(Items.EMERALD, 1), Optional.empty(),
-                    new ItemStack(Items.BREAD, 6), 16, 1, 0.05f));
-            return list;
-        } catch (Exception e) {
-            return new ArrayList<>();
+    private void ensurePreviewOffers() {
+        if (!previewOffers.isEmpty()) return;
+        List<MerchantOffer> live = MerchantInfo.getInfo().getOffers();
+        if (live != null && !live.isEmpty()) {
+            previewOffers = live;
+            sampleFailed = false;
+            return;
         }
+        if (sampleFailed) return;
+        // Try on-demand first (succeeds after data packs are loaded, e.g. in-world)
+        List<MerchantOffer> fresh = OffersHUD.buildSampleOffers();
+        if (!fresh.isEmpty()) {
+            previewOffers = fresh;
+            previewEnchantTexts = OffersHUD.SAMPLE_ENCHANT_TEXTS;
+            return;
+        }
+        // Fallback: pre-generated at init() time
+        if (!OffersHUD.SAMPLE_OFFERS.isEmpty()) {
+            previewOffers = OffersHUD.SAMPLE_OFFERS;
+            previewEnchantTexts = OffersHUD.SAMPLE_ENCHANT_TEXTS;
+            return;
+        }
+        sampleFailed = true;
     }
 
+    private static final int DUMMY_ROWS = 3;
+
     private float scaledW() {
-        return OffersHUDRenderer.calcWidth(previewOffers, this.font) * workScale;
+        if (previewOffers.isEmpty()) return 75 * workScale;
+        return OffersHUDRenderer.calcWidth(previewOffers, previewEnchantTexts, this.font) * workScale;
     }
 
     private float scaledH() {
+        if (previewOffers.isEmpty()) return DUMMY_ROWS * 20 * workScale;
         return OffersHUDRenderer.calcHeight(previewOffers) * workScale;
+    }
+
+    /*? if >= 26.1 {*/
+    private static void renderDummySlots(GuiGraphicsExtractor context, float originX, float originY, float scale) {
+    /*?} else {*/
+    /*private static void renderDummySlots(GuiGraphics context, float originX, float originY, float scale) {
+    *//*?}*/
+        for (int row = 0; row < DUMMY_ROWS; row++) {
+            int baseY = Math.round(originY + row * 20 * scale);
+            int sz = Math.round(16 * scale);
+            int x0 = Math.round(originX);
+            context.fill(x0, baseY, x0 + sz, baseY + sz, 0xFF666666);
+            int x1 = Math.round(originX + 20 * scale);
+            context.fill(x1, baseY, x1 + sz, baseY + sz, 0xFF555555);
+            int x2 = Math.round(originX + 53 * scale);
+            context.fill(x2, baseY, x2 + sz, baseY + sz, 0xFF444444);
+        }
     }
 
     private void recomputeTopLeftFromWork() {
@@ -173,6 +200,7 @@ public class OffersPositionScreen extends Screen {
     /*? if >= 26.1 {*/
     @Override
     public void extractRenderState(GuiGraphicsExtractor context, int mouseX, int mouseY, float partialTick) {
+        ensurePreviewOffers();
         context.fill(0, 0, context.guiWidth(), context.guiHeight(), 0x88000000);
         super.extractRenderState(context, mouseX, mouseY, partialTick);
         context.centeredText(this.font, this.title.getString(), this.width / 2, 10, 0xFFFFFFFF);
@@ -184,12 +212,17 @@ public class OffersPositionScreen extends Screen {
         float sH = scaledH();
         context.fill(Math.round(curX) - 1, Math.round(curY) - 1, Math.round(curX + sW) + 1, Math.round(curY + sH) + 1,
                 boxColor());
-        OffersHUDRenderer.renderOffers(context, this.font, previewOffers, curX, curY, workScale,
-                config.highlightExtremePrices);
+        if (previewOffers.isEmpty()) {
+            renderDummySlots(context, curX, curY, workScale);
+        } else {
+            OffersHUDRenderer.renderOffers(context, this.font, previewOffers, previewEnchantTexts, curX, curY, workScale,
+                    config.highlightExtremePrices);
+        }
     }
     /*?} else {*/
     /*@Override
     public void render(GuiGraphics context, int mouseX, int mouseY, float partialTick) {
+        ensurePreviewOffers();
         context.fill(0, 0, this.width, this.height, 0x88000000);
         super.render(context, mouseX, mouseY, partialTick);
         context.drawCenteredString(this.font, this.title.getString(), this.width / 2, 10, 0xFFFFFFFF);
@@ -201,8 +234,12 @@ public class OffersPositionScreen extends Screen {
         float sH = scaledH();
         context.fill(Math.round(curX) - 1, Math.round(curY) - 1, Math.round(curX + sW) + 1, Math.round(curY + sH) + 1,
                 boxColor());
-        OffersHUDRenderer.renderOffers(context, this.font, previewOffers, curX, curY, workScale,
-                config.highlightExtremePrices);
+        if (previewOffers.isEmpty()) {
+            renderDummySlots(context, curX, curY, workScale);
+        } else {
+            OffersHUDRenderer.renderOffers(context, this.font, previewOffers, previewEnchantTexts, curX, curY, workScale,
+                    config.highlightExtremePrices);
+        }
     }
     *//*?}*/
 

--- a/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
+++ b/src/main/java/net/naari3/offershud/renderer/OffersHUDRenderer.java
@@ -136,9 +136,17 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
 
     /*? if >= 26.1 {*/
     public static void renderOffers(GuiGraphicsExtractor context, Font textRenderer, List<MerchantOffer> offers, float originX, float originY, float scale, boolean highlightExtremePrices) {
+        renderOffers(context, textRenderer, offers, null, originX, originY, scale, highlightExtremePrices);
+    }
+
+    public static void renderOffers(GuiGraphicsExtractor context, Font textRenderer, List<MerchantOffer> offers, List<String> enchantTexts, float originX, float originY, float scale, boolean highlightExtremePrices) {
         var modelMatrices = context.pose();
     /*?} else {*/
     /*public static void renderOffers(GuiGraphics context, Font textRenderer, List<MerchantOffer> offers, float originX, float originY, float scale, boolean highlightExtremePrices) {
+        renderOffers(context, textRenderer, offers, null, originX, originY, scale, highlightExtremePrices);
+    }
+
+    public static void renderOffers(GuiGraphics context, Font textRenderer, List<MerchantOffer> offers, List<String> enchantTexts, float originX, float originY, float scale, boolean highlightExtremePrices) {
         var modelMatrices = context.pose();
     *//*?}*/
 
@@ -199,7 +207,8 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
 
             renderArrow(context, offer, baseX + -20, baseY);
 
-            var enchantments = getEnchantmentText(offer);
+            var enchantments = (enchantTexts != null && i < enchantTexts.size())
+                    ? enchantTexts.get(i) : getEnchantmentText(offer);
 
             /*? if >= 26.1 {*/
             context.text(textRenderer, enchantments, (baseX + 75), (baseY + 5), CommonColors.WHITE);
@@ -423,9 +432,14 @@ public class OffersHUDRenderer implements Platform.HudRenderer {
     }
 
     public static int calcWidth(List<MerchantOffer> offers, Font textRenderer) {
+        return calcWidth(offers, null, textRenderer);
+    }
+
+    public static int calcWidth(List<MerchantOffer> offers, List<String> enchantTexts, Font textRenderer) {
         int maxWidth = 0;
-        for (var offer : offers) {
-            var enchantments = getEnchantmentText(offer);
+        for (int i = 0; i < offers.size(); i++) {
+            var enchantments = (enchantTexts != null && i < enchantTexts.size())
+                    ? enchantTexts.get(i) : getEnchantmentText(offers.get(i));
             int width = 75 + textRenderer.width(enchantments);
             if (width > maxWidth) {
                 maxWidth = width;


### PR DESCRIPTION
## Summary

- Edit Position 画面のプレビューで、アイテムアイコンが灰色のブロックになっていた問題を修正
- NeoForge のモジュールロード順により `builtInRegistryHolder()` が呼ばれたときにホルダーがまだバインドされておらず、`buildSampleOffers()` が "Components not bound yet" でクラッシュしていた
- `Holder.direct(item, DataComponentMap)` を使って registry binding なしで Holder を生成するよう変更。`DataComponents.ITEM_MODEL` を含めることでアイテムレンダラーがモデルを解決できるようにした
- 最初 MC 26.2 のみに適用していたが、同様の問題が MC 26.1 (NeoForge) でも発生することを確認し、`>= 26.1` に拡張

## Versions tested

- 26.2-fabric: アイコン正常表示を確認
- 26.1-neoforge: 修正前は矢印・テキスト・スタック数・アイコンすべて非表示。修正後に正常表示を確認
- 1.21.11-neoforge: 既存コードパス (`< 26.1` branch) で正常動作を確認

## Test plan

- [x] 各バージョンの Edit Position 画面を開き、プレビューにエメラルド・ダイヤモンド・エンチャント本・パンのアイコンが正しく表示されること
- [x] タイトル画面から開いた場合も同様に動作すること
- [x] インゲームで商人にカーソルを当てた状態で開いた場合、実トレードが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)