### PR TITLE
Parallelize publish workflow build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     outputs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Get versions list
         id: versions
         run: |
@@ -31,14 +31,14 @@ jobs:
       matrix:
         version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 25
       - name: Cache Gradle wrapper and dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/wrapper
@@ -46,14 +46,14 @@ jobs:
           key: ${{ runner.os }}-gradle-deps-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
           restore-keys: ${{ runner.os }}-gradle-deps-
       - name: Cache loom
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .gradle/loom-cache
           key: ${{ runner.os }}-loom-${{ matrix.version }}-${{ hashFiles(format('versions/{0}/gradle.properties', matrix.version)) }}
           restore-keys: ${{ runner.os }}-loom-${{ matrix.version }}-
       - name: Build with Gradle
         run: ./gradlew :${{ matrix.version }}:build --configure-on-demand
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.version }}
           path: versions/${{ matrix.version }}/build/libs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Cache loom
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/loom-cache
+          path: .gradle/loom-cache
           key: ${{ runner.os }}-loom-${{ matrix.version }}-${{ hashFiles(format('versions/{0}/gradle.properties', matrix.version)) }}
           restore-keys: ${{ runner.os }}-loom-${{ matrix.version }}-
       - name: Build with Gradle

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,25 @@ on:
   pull_request:
 
 jobs:
+  get-versions:
+    runs-on: ubuntu-latest
+    outputs:
+      versions: ${{ steps.versions.outputs.versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get versions list
+        id: versions
+        run: |
+          versions=$(ls -1 versions/ | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "versions=$versions" >> $GITHUB_OUTPUT
+
   build:
     runs-on: ubuntu-latest
-
+    needs: [get-versions]
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.get-versions.outputs.versions) }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 25
@@ -21,18 +37,23 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 25
-      - name: Cache Gradle packages
+      - name: Cache Gradle wrapper and dependencies
         uses: actions/cache@v4
         with:
           path: |
-            ~/.gradle/loom-cache
             ~/.gradle/wrapper
             ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          key: ${{ runner.os }}-gradle-deps-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+          restore-keys: ${{ runner.os }}-gradle-deps-
+      - name: Cache loom
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/loom-cache
+          key: ${{ runner.os }}-loom-${{ matrix.version }}-${{ hashFiles(format('versions/{0}/gradle.properties', matrix.version)) }}
+          restore-keys: ${{ runner.os }}-loom-${{ matrix.version }}-
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew :${{ matrix.version }}:build --configure-on-demand
       - uses: actions/upload-artifact@v4
         with:
-          name: Compiled artifacts for ${{ github.sha }}
-          path: versions/*/build/libs
+          name: build-${{ matrix.version }}
+          path: versions/${{ matrix.version }}/build/libs

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Cache loom
         uses: actions/cache@v4
         with:
-          path: ~/.gradle/loom-cache
+          path: .gradle/loom-cache
           key: ${{ runner.os }}-loom-${{ matrix.version }}-${{ hashFiles(format('versions/{0}/gradle.properties', matrix.version)) }}
           restore-keys: ${{ runner.os }}-loom-${{ matrix.version }}-
       - name: Build with Gradle

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -14,7 +14,7 @@ jobs:
       versions: ${{ steps.versions.outputs.versions }}
     steps:
       - name: Checkout the sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Determine release type
         id: type
         run: |
@@ -49,14 +49,14 @@ jobs:
         version: ${{ fromJSON(needs.get-properties.outputs.versions) }}
     steps:
       - name: Checkout the sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: "temurin"
           java-version: 25
       - name: Cache Gradle wrapper and dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/wrapper
@@ -64,14 +64,14 @@ jobs:
           key: ${{ runner.os }}-gradle-deps-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
           restore-keys: ${{ runner.os }}-gradle-deps-
       - name: Cache loom
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .gradle/loom-cache
           key: ${{ runner.os }}-loom-${{ matrix.version }}-${{ hashFiles(format('versions/{0}/gradle.properties', matrix.version)) }}
           restore-keys: ${{ runner.os }}-loom-${{ matrix.version }}-
       - name: Build with Gradle
         run: ./gradlew :${{ matrix.version }}:build --configure-on-demand
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: build-${{ matrix.version }}
           path: versions/${{ matrix.version }}/build/libs
@@ -83,8 +83,8 @@ jobs:
       targets: ${{ steps.findjar.outputs.targets }}
     steps:
       - name: Checkout the sources
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+        uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           pattern: build-*
           path: artifacts
@@ -106,7 +106,7 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: ${{ steps.findjar.outputs.jar_files }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: Compiled artifacts for ${{ github.sha }}
           path: artifacts
@@ -120,8 +120,8 @@ jobs:
         file: ${{ fromJSON(needs.release.outputs.targets) }}
     steps:
       - name: Checkout the sources
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+        uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
         with:
           name: Compiled artifacts for ${{ github.sha }}
           path: artifacts

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -11,6 +11,7 @@ jobs:
       mod-version: ${{ steps.properties.outputs.mod_version }}
       minecraft-version: ${{ steps.properties.outputs.minecraft_version }}
       curse-versions: ${{ steps.properties.outputs.release-curse-versions }}
+      versions: ${{ steps.versions.outputs.versions }}
     steps:
       - name: Checkout the sources
         uses: actions/checkout@v4
@@ -33,17 +34,20 @@ jobs:
             echo "$property: $result"
             echo "$property=$result" >> $GITHUB_OUTPUT
           done
-  build-and-publish:
+      - name: Get versions list
+        id: versions
+        run: |
+          versions=$(ls -1 versions/ | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "versions=$versions" >> $GITHUB_OUTPUT
+
+  build:
     runs-on: ubuntu-latest
     needs: [get-properties]
-    outputs:
-      targets: ${{ steps.findjar.outputs.targets }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{ fromJSON(needs.get-properties.outputs.versions) }}
     steps:
-      - name: Get info from branch to run
-        id: getbranchinfo
-        run: |
-          echo "version=${{ needs.get-properties.outputs.minecraft-version }}" >> $GITHUB_OUTPUT
-          echo "curse-versions=${{ needs.get-properties.outputs.curse-versions }}" >> $GITHUB_OUTPUT
       - name: Checkout the sources
         uses: actions/checkout@v4
       - name: Set up JDK 25
@@ -51,21 +55,43 @@ jobs:
         with:
           distribution: "temurin"
           java-version: 25
-      - name: Cache Gradle packages
+      - name: Cache Gradle wrapper and dependencies
         uses: actions/cache@v4
         with:
           path: |
-            ~/.gradle/loom-cache
             ~/.gradle/wrapper
             ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          key: ${{ runner.os }}-gradle-deps-${{ hashFiles('**/*.gradle', '**/*.gradle.kts') }}
+          restore-keys: ${{ runner.os }}-gradle-deps-
+      - name: Cache loom
+        uses: actions/cache@v4
+        with:
+          path: ~/.gradle/loom-cache
+          key: ${{ runner.os }}-loom-${{ matrix.version }}-${{ hashFiles(format('versions/{0}/gradle.properties', matrix.version)) }}
+          restore-keys: ${{ runner.os }}-loom-${{ matrix.version }}-
       - name: Build with Gradle
-        run: ./gradlew build
-      - name: Find correct JAR
+        run: ./gradlew :${{ matrix.version }}:build --configure-on-demand
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.version }}
+          path: versions/${{ matrix.version }}/build/libs
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build, get-properties]
+    outputs:
+      targets: ${{ steps.findjar.outputs.targets }}
+    steps:
+      - name: Checkout the sources
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: build-*
+          path: artifacts
+      - name: Find correct JARs
         id: findjar
         run: |
-          jar_files=$(find versions -type f -path "*/build/libs/offers-hud-*+*.jar" | grep -v "sources")
+          jar_files=$(find artifacts -type f -name "offers-hud-*+*.jar" | grep -v "sources")
           echo "jar_files<<EOF" >> $GITHUB_OUTPUT
           echo "$jar_files" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -73,10 +99,6 @@ jobs:
           targets=$(echo -n $jar_files | jq -R -s -c 'split(" ")')
           echo targets=$targets >> $GITHUB_OUTPUT
           echo "$targets"
-      - uses: actions/upload-artifact@v4
-        with:
-          name: Compiled artifacts for ${{ github.sha }}
-          path: versions/*/build/libs
       - name: Upload to the Github release
         uses: softprops/action-gh-release@v2
         env:
@@ -84,20 +106,25 @@ jobs:
         with:
           tag_name: ${{ github.event.release.tag_name }}
           files: ${{ steps.findjar.outputs.jar_files }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: Compiled artifacts for ${{ github.sha }}
+          path: artifacts
+
   publish-to-mod-repos:
     runs-on: ubuntu-latest
-    needs: [build-and-publish, get-properties]
+    needs: [release, get-properties]
     strategy:
       fail-fast: true
       matrix:
-        file: ${{ fromJSON(needs.build-and-publish.outputs.targets) }}
+        file: ${{ fromJSON(needs.release.outputs.targets) }}
     steps:
       - name: Checkout the sources
         uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: Compiled artifacts for ${{ github.sha }}
-          path: versions
+          path: artifacts
       - name: Get Minecraft Version and Loader from filename
         id: getmcversion
         run: |


### PR DESCRIPTION
## Summary

- \`build-and-publish\` ジョブを \`build\`（matrix 20並列）と \`release\`（集約）に分割
- 各バージョンを \`./gradlew :<version>:build\` で並列ビルド
- バージョンリストは \`ls versions/\` から動的取得（バージョン追加時にワークフロー修正不要）
- Gradleキャッシュを共有deps（\`gradle-deps-\`）とバージョン別loom-cache（\`loom-<version>-\`）に分離

## Test plan

**PRの段階で確認できること**
- [x] 全バージョンが並列でビルドされること（build CIで確認可）
- [x] キャッシュが正しく効くこと（Cache loom / Cache Gradle wrapper stepで確認）

**マージ後にリリースを打って確認すること**
- [ ] GitHub ReleaseにJARがアップロードされること
- [ ] Modrinth / CurseForgeにpublishされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)