### PR TITLE
Fix GitHub release upload by explicitly specifying tag_name

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -82,6 +82,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          tag_name: ${{ github.event.release.tag_name }}
           files: ${{ steps.findjar.outputs.jar_files }}
   publish-to-mod-repos:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- `softprops/action-gh-release@v2` に `tag_name: ${{ github.event.release.tag_name }}` を明示的に追加
- `GITHUB_REF` からタグが取得できずに発生していた「GitHub Releases requires a tag」エラーを修正

## Test plan
- マージ後、v2.5.0 リリースを re-publish して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)